### PR TITLE
align the line numbers

### DIFF
--- a/src/components/stackTrace/components/FrameCodeSnippet.tsx
+++ b/src/components/stackTrace/components/FrameCodeSnippet.tsx
@@ -81,7 +81,7 @@ export default function FrameCodeSnippet({ frame }: Props) {
     return (
         <main className="flex items-stretch flex-grow overflow-x-auto overflow-y-hidden scrollbar-hidden-x mask-fade-r text-sm">
             <nav className="sticky left-0 flex flex-none z-20 ~bg-white">
-                <div className="select-none">
+                <div className="select-none text-right">
                     {lineNumbers.map((number) => (
                         <p
                             key={number}


### PR DESCRIPTION
Right aligns the line numbers in a stack trace.

### Before
<img width="111" alt="Screenshot 2022-07-26 at 15 03 22" src="https://user-images.githubusercontent.com/16917762/181012649-851192fb-d640-431c-9eca-aa08d2109cbe.png">

### After
<img width="111" alt="Screenshot 2022-07-26 at 15 02 44" src="https://user-images.githubusercontent.com/16917762/181012635-2bd35034-c96a-42cb-b720-3b0fea8d6e9d.png">

