### PR TITLE
Tweak Ignition UI components to better match Laravel's new splash screen

### DIFF
--- a/dist/index.modern.js
+++ b/dist/index.modern.js
@@ -66,20 +66,20 @@ var a = () => {
     }
   }, []), s;
 },
-    d$1 = a;
+    d$2 = a;
 
 function IgnitionConfigContextProvider({
   children,
   ignitionConfig: initialIgnitionConfig
 }) {
   const [ignitionConfig, setIgnitionConfig] = useState(initialIgnitionConfig);
-  const scheme = d$1();
+  const scheme = d$2();
   const theme = ignitionConfig.theme === 'auto' ? scheme !== 'no-preference' ? scheme : 'light' : ignitionConfig.theme;
   useEffect(() => {
     document.documentElement.classList.remove('light', 'dark', 'auto');
     document.documentElement.classList.add(theme);
   }, [theme]);
-  return /*#__PURE__*/React__default.createElement(IgnitionConfigContext.Provider, {
+  return React__default.createElement(IgnitionConfigContext.Provider, {
     value: {
       ignitionConfig,
       setIgnitionConfig,
@@ -121,7 +121,7 @@ var _Symbol = Symbol$1;
 var objectProto$e = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$c = objectProto$e.hasOwnProperty;
+var hasOwnProperty$b = objectProto$e.hasOwnProperty;
 /**
  * Used to resolve the
  * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
@@ -141,7 +141,7 @@ var symToStringTag$1 = _Symbol ? _Symbol.toStringTag : undefined;
  */
 
 function getRawTag(value) {
-  var isOwn = hasOwnProperty$c.call(value, symToStringTag$1),
+  var isOwn = hasOwnProperty$b.call(value, symToStringTag$1),
       tag = value[symToStringTag$1];
 
   try {
@@ -354,10 +354,10 @@ var funcProto = Function.prototype,
 var funcToString = funcProto.toString;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$b = objectProto$c.hasOwnProperty;
+var hasOwnProperty$a = objectProto$c.hasOwnProperty;
 /** Used to detect if a method is native. */
 
-var reIsNative = RegExp('^' + funcToString.call(hasOwnProperty$b).replace(reRegExpChar, '\\$&').replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
+var reIsNative = RegExp('^' + funcToString.call(hasOwnProperty$a).replace(reRegExpChar, '\\$&').replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
 /**
  * The base implementation of `_.isNative` without bad shim checks.
  *
@@ -560,7 +560,7 @@ var _baseIsArguments = baseIsArguments;
 var objectProto$b = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$a = objectProto$b.hasOwnProperty;
+var hasOwnProperty$9 = objectProto$b.hasOwnProperty;
 /** Built-in value references. */
 
 var propertyIsEnumerable$1 = objectProto$b.propertyIsEnumerable;
@@ -586,7 +586,7 @@ var propertyIsEnumerable$1 = objectProto$b.propertyIsEnumerable;
 var isArguments = _baseIsArguments(function () {
   return arguments;
 }()) ? _baseIsArguments : function (value) {
-  return isObjectLike_1(value) && hasOwnProperty$a.call(value, 'callee') && !propertyIsEnumerable$1.call(value, 'callee');
+  return isObjectLike_1(value) && hasOwnProperty$9.call(value, 'callee') && !propertyIsEnumerable$1.call(value, 'callee');
 };
 var isArguments_1 = isArguments;
 
@@ -849,7 +849,7 @@ var isTypedArray_1 = isTypedArray;
 var objectProto$a = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$9 = objectProto$a.hasOwnProperty;
+var hasOwnProperty$8 = objectProto$a.hasOwnProperty;
 /**
  * Creates an array of the enumerable property names of the array-like `value`.
  *
@@ -869,7 +869,7 @@ function arrayLikeKeys(value, inherited) {
       length = result.length;
 
   for (var key in value) {
-    if ((inherited || hasOwnProperty$9.call(value, key)) && !(skipIndexes && ( // Safari 9 has enumerable `arguments.length` in strict mode.
+    if ((inherited || hasOwnProperty$8.call(value, key)) && !(skipIndexes && ( // Safari 9 has enumerable `arguments.length` in strict mode.
     key == 'length' || // Node.js 0.10 has enumerable non-index properties on buffers.
     isBuff && (key == 'offset' || key == 'parent') || // PhantomJS 2 has enumerable non-index properties on typed arrays.
     isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset') || // Skip index properties.
@@ -927,7 +927,7 @@ var _nativeKeys = nativeKeys;
 var objectProto$8 = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$8 = objectProto$8.hasOwnProperty;
+var hasOwnProperty$7 = objectProto$8.hasOwnProperty;
 /**
  * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
  *
@@ -944,7 +944,7 @@ function baseKeys(object) {
   var result = [];
 
   for (var key in Object(object)) {
-    if (hasOwnProperty$8.call(object, key) && key != 'constructor') {
+    if (hasOwnProperty$7.call(object, key) && key != 'constructor') {
       result.push(key);
     }
   }
@@ -1351,7 +1351,7 @@ var HASH_UNDEFINED$2 = '__lodash_hash_undefined__';
 var objectProto$7 = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$7 = objectProto$7.hasOwnProperty;
+var hasOwnProperty$6 = objectProto$7.hasOwnProperty;
 /**
  * Gets the hash value for `key`.
  *
@@ -1370,7 +1370,7 @@ function hashGet(key) {
     return result === HASH_UNDEFINED$2 ? undefined : result;
   }
 
-  return hasOwnProperty$7.call(data, key) ? data[key] : undefined;
+  return hasOwnProperty$6.call(data, key) ? data[key] : undefined;
 }
 
 var _hashGet = hashGet;
@@ -1380,7 +1380,7 @@ var _hashGet = hashGet;
 var objectProto$6 = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$6 = objectProto$6.hasOwnProperty;
+var hasOwnProperty$5 = objectProto$6.hasOwnProperty;
 /**
  * Checks if a hash value for `key` exists.
  *
@@ -1393,7 +1393,7 @@ var hasOwnProperty$6 = objectProto$6.hasOwnProperty;
 
 function hashHas(key) {
   var data = this.__data__;
-  return _nativeCreate ? data[key] !== undefined : hasOwnProperty$6.call(data, key);
+  return _nativeCreate ? data[key] !== undefined : hasOwnProperty$5.call(data, key);
 }
 
 var _hashHas = hashHas;
@@ -2127,7 +2127,7 @@ var COMPARE_PARTIAL_FLAG$3 = 1;
 var objectProto$4 = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$5 = objectProto$4.hasOwnProperty;
+var hasOwnProperty$4 = objectProto$4.hasOwnProperty;
 /**
  * A specialized version of `baseIsEqualDeep` for objects with support for
  * partial deep comparisons.
@@ -2158,7 +2158,7 @@ function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
   while (index--) {
     var key = objProps[index];
 
-    if (!(isPartial ? key in other : hasOwnProperty$5.call(other, key))) {
+    if (!(isPartial ? key in other : hasOwnProperty$4.call(other, key))) {
       return false;
     }
   } // Check that cyclic values are equal.
@@ -2299,7 +2299,7 @@ var argsTag = '[object Arguments]',
 var objectProto$3 = Object.prototype;
 /** Used to check objects for own properties. */
 
-var hasOwnProperty$4 = objectProto$3.hasOwnProperty;
+var hasOwnProperty$3 = objectProto$3.hasOwnProperty;
 /**
  * A specialized version of `baseIsEqual` for arrays and objects which performs
  * deep comparisons and tracks traversed objects enabling objects with circular
@@ -2341,8 +2341,8 @@ function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
   }
 
   if (!(bitmask & COMPARE_PARTIAL_FLAG$2)) {
-    var objIsWrapped = objIsObj && hasOwnProperty$4.call(object, '__wrapped__'),
-        othIsWrapped = othIsObj && hasOwnProperty$4.call(other, '__wrapped__');
+    var objIsWrapped = objIsObj && hasOwnProperty$3.call(object, '__wrapped__'),
+        othIsWrapped = othIsObj && hasOwnProperty$3.call(other, '__wrapped__');
 
     if (objIsWrapped || othIsWrapped) {
       var objUnwrapped = objIsWrapped ? object.value() : object,
@@ -3382,7 +3382,7 @@ var TAGNAMES_TO_SKIP_FOR_PSEUDOELEMENTS = ['HTML', 'HEAD', 'STYLE', 'SCRIPT'];
 
 var PRODUCTION$1 = function () {
   try {
-    return "development" === 'production';
+    return "production" === 'production';
   } catch (e) {
     return false;
   }
@@ -3537,7 +3537,7 @@ function onChange(cb) {
   };
 }
 
-var d = UNITS_IN_GRID;
+var d$1 = UNITS_IN_GRID;
 var meaninglessTransform = {
   size: 16,
   x: 0,
@@ -3658,14 +3658,14 @@ function transformForCss(_ref2) {
   var val = '';
 
   if (startCentered && IS_IE) {
-    val += "translate(".concat(transform.x / d - width / 2, "em, ").concat(transform.y / d - height / 2, "em) ");
+    val += "translate(".concat(transform.x / d$1 - width / 2, "em, ").concat(transform.y / d$1 - height / 2, "em) ");
   } else if (startCentered) {
-    val += "translate(calc(-50% + ".concat(transform.x / d, "em), calc(-50% + ").concat(transform.y / d, "em)) ");
+    val += "translate(calc(-50% + ".concat(transform.x / d$1, "em), calc(-50% + ").concat(transform.y / d$1, "em)) ");
   } else {
-    val += "translate(".concat(transform.x / d, "em, ").concat(transform.y / d, "em) ");
+    val += "translate(".concat(transform.x / d$1, "em, ").concat(transform.y / d$1, "em) ");
   }
 
-  val += "scale(".concat(transform.size / d * (transform.flipX ? -1 : 1), ", ").concat(transform.size / d * (transform.flipY ? -1 : 1), ") ");
+  val += "scale(".concat(transform.size / d$1 * (transform.flipX ? -1 : 1), ", ").concat(transform.size / d$1 * (transform.flipY ? -1 : 1), ") ");
   val += "rotate(".concat(transform.rotate, "deg) ");
   return val;
 }
@@ -3718,12 +3718,12 @@ var InjectCSS = {
     };
   }
 };
-var w = WINDOW || {};
-if (!w[NAMESPACE_IDENTIFIER]) w[NAMESPACE_IDENTIFIER] = {};
-if (!w[NAMESPACE_IDENTIFIER].styles) w[NAMESPACE_IDENTIFIER].styles = {};
-if (!w[NAMESPACE_IDENTIFIER].hooks) w[NAMESPACE_IDENTIFIER].hooks = {};
-if (!w[NAMESPACE_IDENTIFIER].shims) w[NAMESPACE_IDENTIFIER].shims = [];
-var namespace = w[NAMESPACE_IDENTIFIER];
+var w$1 = WINDOW || {};
+if (!w$1[NAMESPACE_IDENTIFIER]) w$1[NAMESPACE_IDENTIFIER] = {};
+if (!w$1[NAMESPACE_IDENTIFIER].styles) w$1[NAMESPACE_IDENTIFIER].styles = {};
+if (!w$1[NAMESPACE_IDENTIFIER].hooks) w$1[NAMESPACE_IDENTIFIER].hooks = {};
+if (!w$1[NAMESPACE_IDENTIFIER].shims) w$1[NAMESPACE_IDENTIFIER].shims = [];
+var namespace = w$1[NAMESPACE_IDENTIFIER];
 var functions = [];
 
 var listener = function listener() {
@@ -4746,22 +4746,22 @@ function findIcon(iconName, prefix) {
 
 var noop$1$1 = function noop() {};
 
-var p = config.measurePerformance && PERFORMANCE && PERFORMANCE.mark && PERFORMANCE.measure ? PERFORMANCE : {
+var p$1 = config.measurePerformance && PERFORMANCE && PERFORMANCE.mark && PERFORMANCE.measure ? PERFORMANCE : {
   mark: noop$1$1,
   measure: noop$1$1
 };
 var preamble = "FA \"6.1.1\"";
 
 var begin = function begin(name) {
-  p.mark("".concat(preamble, " ").concat(name, " begins"));
+  p$1.mark("".concat(preamble, " ").concat(name, " begins"));
   return function () {
     return end(name);
   };
 };
 
 var end = function end(name) {
-  p.mark("".concat(preamble, " ").concat(name, " ends"));
-  p.measure("".concat(preamble, " ").concat(name), "".concat(preamble, " ").concat(name, " begins"), "".concat(preamble, " ").concat(name, " ends"));
+  p$1.mark("".concat(preamble, " ").concat(name, " ends"));
+  p$1.measure("".concat(preamble, " ").concat(name), "".concat(preamble, " ").concat(name, " begins"), "".concat(preamble, " ").concat(name, " ends"));
 };
 
 var perf = {
@@ -6075,6 +6075,175 @@ var parse$1 = api.parse;
 var icon = api.icon;
 
 /** @license React v16.13.1
+ * react-is.production.min.js
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var b = "function" === typeof Symbol && Symbol.for,
+    c = b ? Symbol.for("react.element") : 60103,
+    d = b ? Symbol.for("react.portal") : 60106,
+    e = b ? Symbol.for("react.fragment") : 60107,
+    f = b ? Symbol.for("react.strict_mode") : 60108,
+    g = b ? Symbol.for("react.profiler") : 60114,
+    h = b ? Symbol.for("react.provider") : 60109,
+    k = b ? Symbol.for("react.context") : 60110,
+    l = b ? Symbol.for("react.async_mode") : 60111,
+    m = b ? Symbol.for("react.concurrent_mode") : 60111,
+    n = b ? Symbol.for("react.forward_ref") : 60112,
+    p = b ? Symbol.for("react.suspense") : 60113,
+    q = b ? Symbol.for("react.suspense_list") : 60120,
+    r = b ? Symbol.for("react.memo") : 60115,
+    t = b ? Symbol.for("react.lazy") : 60116,
+    v = b ? Symbol.for("react.block") : 60121,
+    w = b ? Symbol.for("react.fundamental") : 60117,
+    x = b ? Symbol.for("react.responder") : 60118,
+    y = b ? Symbol.for("react.scope") : 60119;
+
+function z(a) {
+  if ("object" === typeof a && null !== a) {
+    var u = a.$$typeof;
+
+    switch (u) {
+      case c:
+        switch (a = a.type, a) {
+          case l:
+          case m:
+          case e:
+          case g:
+          case f:
+          case p:
+            return a;
+
+          default:
+            switch (a = a && a.$$typeof, a) {
+              case k:
+              case n:
+              case t:
+              case r:
+              case h:
+                return a;
+
+              default:
+                return u;
+            }
+
+        }
+
+      case d:
+        return u;
+    }
+  }
+}
+
+function A(a) {
+  return z(a) === m;
+}
+
+var AsyncMode = l;
+var ConcurrentMode = m;
+var ContextConsumer = k;
+var ContextProvider = h;
+var Element = c;
+var ForwardRef = n;
+var Fragment = e;
+var Lazy = t;
+var Memo = r;
+var Portal = d;
+var Profiler = g;
+var StrictMode = f;
+var Suspense = p;
+
+var isAsyncMode = function isAsyncMode(a) {
+  return A(a) || z(a) === l;
+};
+
+var isConcurrentMode = A;
+
+var isContextConsumer = function isContextConsumer(a) {
+  return z(a) === k;
+};
+
+var isContextProvider = function isContextProvider(a) {
+  return z(a) === h;
+};
+
+var isElement = function isElement(a) {
+  return "object" === typeof a && null !== a && a.$$typeof === c;
+};
+
+var isForwardRef = function isForwardRef(a) {
+  return z(a) === n;
+};
+
+var isFragment = function isFragment(a) {
+  return z(a) === e;
+};
+
+var isLazy = function isLazy(a) {
+  return z(a) === t;
+};
+
+var isMemo = function isMemo(a) {
+  return z(a) === r;
+};
+
+var isPortal = function isPortal(a) {
+  return z(a) === d;
+};
+
+var isProfiler = function isProfiler(a) {
+  return z(a) === g;
+};
+
+var isStrictMode = function isStrictMode(a) {
+  return z(a) === f;
+};
+
+var isSuspense = function isSuspense(a) {
+  return z(a) === p;
+};
+
+var isValidElementType = function isValidElementType(a) {
+  return "string" === typeof a || "function" === typeof a || a === e || a === m || a === g || a === f || a === p || a === q || "object" === typeof a && null !== a && (a.$$typeof === t || a.$$typeof === r || a.$$typeof === h || a.$$typeof === k || a.$$typeof === n || a.$$typeof === w || a.$$typeof === x || a.$$typeof === y || a.$$typeof === v);
+};
+
+var typeOf = z;
+var reactIs_production_min = {
+  AsyncMode: AsyncMode,
+  ConcurrentMode: ConcurrentMode,
+  ContextConsumer: ContextConsumer,
+  ContextProvider: ContextProvider,
+  Element: Element,
+  ForwardRef: ForwardRef,
+  Fragment: Fragment,
+  Lazy: Lazy,
+  Memo: Memo,
+  Portal: Portal,
+  Profiler: Profiler,
+  StrictMode: StrictMode,
+  Suspense: Suspense,
+  isAsyncMode: isAsyncMode,
+  isConcurrentMode: isConcurrentMode,
+  isContextConsumer: isContextConsumer,
+  isContextProvider: isContextProvider,
+  isElement: isElement,
+  isForwardRef: isForwardRef,
+  isFragment: isFragment,
+  isLazy: isLazy,
+  isMemo: isMemo,
+  isPortal: isPortal,
+  isProfiler: isProfiler,
+  isStrictMode: isStrictMode,
+  isSuspense: isSuspense,
+  isValidElementType: isValidElementType,
+  typeOf: typeOf
+};
+
+/** @license React v16.13.1
  * react-is.development.js
  *
  * Copyright (c) Facebook, Inc. and its affiliates.
@@ -6082,289 +6251,27 @@ var icon = api.icon;
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var reactIs_development = createCommonjsModule(function (module, exports) {
+createCommonjsModule(function (module, exports) {
+});
+
+createCommonjsModule(function (module) {
 
   {
-    (function () {
-      // nor polyfill, then a plain number is used for performance.
-
-      var hasSymbol = typeof Symbol === 'function' && Symbol.for;
-      var REACT_ELEMENT_TYPE = hasSymbol ? Symbol.for('react.element') : 0xeac7;
-      var REACT_PORTAL_TYPE = hasSymbol ? Symbol.for('react.portal') : 0xeaca;
-      var REACT_FRAGMENT_TYPE = hasSymbol ? Symbol.for('react.fragment') : 0xeacb;
-      var REACT_STRICT_MODE_TYPE = hasSymbol ? Symbol.for('react.strict_mode') : 0xeacc;
-      var REACT_PROFILER_TYPE = hasSymbol ? Symbol.for('react.profiler') : 0xead2;
-      var REACT_PROVIDER_TYPE = hasSymbol ? Symbol.for('react.provider') : 0xeacd;
-      var REACT_CONTEXT_TYPE = hasSymbol ? Symbol.for('react.context') : 0xeace; // TODO: We don't use AsyncMode or ConcurrentMode anymore. They were temporary
-      // (unstable) APIs that have been removed. Can we remove the symbols?
-
-      var REACT_ASYNC_MODE_TYPE = hasSymbol ? Symbol.for('react.async_mode') : 0xeacf;
-      var REACT_CONCURRENT_MODE_TYPE = hasSymbol ? Symbol.for('react.concurrent_mode') : 0xeacf;
-      var REACT_FORWARD_REF_TYPE = hasSymbol ? Symbol.for('react.forward_ref') : 0xead0;
-      var REACT_SUSPENSE_TYPE = hasSymbol ? Symbol.for('react.suspense') : 0xead1;
-      var REACT_SUSPENSE_LIST_TYPE = hasSymbol ? Symbol.for('react.suspense_list') : 0xead8;
-      var REACT_MEMO_TYPE = hasSymbol ? Symbol.for('react.memo') : 0xead3;
-      var REACT_LAZY_TYPE = hasSymbol ? Symbol.for('react.lazy') : 0xead4;
-      var REACT_BLOCK_TYPE = hasSymbol ? Symbol.for('react.block') : 0xead9;
-      var REACT_FUNDAMENTAL_TYPE = hasSymbol ? Symbol.for('react.fundamental') : 0xead5;
-      var REACT_RESPONDER_TYPE = hasSymbol ? Symbol.for('react.responder') : 0xead6;
-      var REACT_SCOPE_TYPE = hasSymbol ? Symbol.for('react.scope') : 0xead7;
-
-      function isValidElementType(type) {
-        return typeof type === 'string' || typeof type === 'function' || // Note: its typeof might be other than 'symbol' or 'number' if it's a polyfill.
-        type === REACT_FRAGMENT_TYPE || type === REACT_CONCURRENT_MODE_TYPE || type === REACT_PROFILER_TYPE || type === REACT_STRICT_MODE_TYPE || type === REACT_SUSPENSE_TYPE || type === REACT_SUSPENSE_LIST_TYPE || typeof type === 'object' && type !== null && (type.$$typeof === REACT_LAZY_TYPE || type.$$typeof === REACT_MEMO_TYPE || type.$$typeof === REACT_PROVIDER_TYPE || type.$$typeof === REACT_CONTEXT_TYPE || type.$$typeof === REACT_FORWARD_REF_TYPE || type.$$typeof === REACT_FUNDAMENTAL_TYPE || type.$$typeof === REACT_RESPONDER_TYPE || type.$$typeof === REACT_SCOPE_TYPE || type.$$typeof === REACT_BLOCK_TYPE);
-      }
-
-      function typeOf(object) {
-        if (typeof object === 'object' && object !== null) {
-          var $$typeof = object.$$typeof;
-
-          switch ($$typeof) {
-            case REACT_ELEMENT_TYPE:
-              var type = object.type;
-
-              switch (type) {
-                case REACT_ASYNC_MODE_TYPE:
-                case REACT_CONCURRENT_MODE_TYPE:
-                case REACT_FRAGMENT_TYPE:
-                case REACT_PROFILER_TYPE:
-                case REACT_STRICT_MODE_TYPE:
-                case REACT_SUSPENSE_TYPE:
-                  return type;
-
-                default:
-                  var $$typeofType = type && type.$$typeof;
-
-                  switch ($$typeofType) {
-                    case REACT_CONTEXT_TYPE:
-                    case REACT_FORWARD_REF_TYPE:
-                    case REACT_LAZY_TYPE:
-                    case REACT_MEMO_TYPE:
-                    case REACT_PROVIDER_TYPE:
-                      return $$typeofType;
-
-                    default:
-                      return $$typeof;
-                  }
-
-              }
-
-            case REACT_PORTAL_TYPE:
-              return $$typeof;
-          }
-        }
-
-        return undefined;
-      } // AsyncMode is deprecated along with isAsyncMode
-
-
-      var AsyncMode = REACT_ASYNC_MODE_TYPE;
-      var ConcurrentMode = REACT_CONCURRENT_MODE_TYPE;
-      var ContextConsumer = REACT_CONTEXT_TYPE;
-      var ContextProvider = REACT_PROVIDER_TYPE;
-      var Element = REACT_ELEMENT_TYPE;
-      var ForwardRef = REACT_FORWARD_REF_TYPE;
-      var Fragment = REACT_FRAGMENT_TYPE;
-      var Lazy = REACT_LAZY_TYPE;
-      var Memo = REACT_MEMO_TYPE;
-      var Portal = REACT_PORTAL_TYPE;
-      var Profiler = REACT_PROFILER_TYPE;
-      var StrictMode = REACT_STRICT_MODE_TYPE;
-      var Suspense = REACT_SUSPENSE_TYPE;
-      var hasWarnedAboutDeprecatedIsAsyncMode = false; // AsyncMode should be deprecated
-
-      function isAsyncMode(object) {
-        {
-          if (!hasWarnedAboutDeprecatedIsAsyncMode) {
-            hasWarnedAboutDeprecatedIsAsyncMode = true; // Using console['warn'] to evade Babel and ESLint
-
-            console['warn']('The ReactIs.isAsyncMode() alias has been deprecated, ' + 'and will be removed in React 17+. Update your code to use ' + 'ReactIs.isConcurrentMode() instead. It has the exact same API.');
-          }
-        }
-        return isConcurrentMode(object) || typeOf(object) === REACT_ASYNC_MODE_TYPE;
-      }
-
-      function isConcurrentMode(object) {
-        return typeOf(object) === REACT_CONCURRENT_MODE_TYPE;
-      }
-
-      function isContextConsumer(object) {
-        return typeOf(object) === REACT_CONTEXT_TYPE;
-      }
-
-      function isContextProvider(object) {
-        return typeOf(object) === REACT_PROVIDER_TYPE;
-      }
-
-      function isElement(object) {
-        return typeof object === 'object' && object !== null && object.$$typeof === REACT_ELEMENT_TYPE;
-      }
-
-      function isForwardRef(object) {
-        return typeOf(object) === REACT_FORWARD_REF_TYPE;
-      }
-
-      function isFragment(object) {
-        return typeOf(object) === REACT_FRAGMENT_TYPE;
-      }
-
-      function isLazy(object) {
-        return typeOf(object) === REACT_LAZY_TYPE;
-      }
-
-      function isMemo(object) {
-        return typeOf(object) === REACT_MEMO_TYPE;
-      }
-
-      function isPortal(object) {
-        return typeOf(object) === REACT_PORTAL_TYPE;
-      }
-
-      function isProfiler(object) {
-        return typeOf(object) === REACT_PROFILER_TYPE;
-      }
-
-      function isStrictMode(object) {
-        return typeOf(object) === REACT_STRICT_MODE_TYPE;
-      }
-
-      function isSuspense(object) {
-        return typeOf(object) === REACT_SUSPENSE_TYPE;
-      }
-
-      exports.AsyncMode = AsyncMode;
-      exports.ConcurrentMode = ConcurrentMode;
-      exports.ContextConsumer = ContextConsumer;
-      exports.ContextProvider = ContextProvider;
-      exports.Element = Element;
-      exports.ForwardRef = ForwardRef;
-      exports.Fragment = Fragment;
-      exports.Lazy = Lazy;
-      exports.Memo = Memo;
-      exports.Portal = Portal;
-      exports.Profiler = Profiler;
-      exports.StrictMode = StrictMode;
-      exports.Suspense = Suspense;
-      exports.isAsyncMode = isAsyncMode;
-      exports.isConcurrentMode = isConcurrentMode;
-      exports.isContextConsumer = isContextConsumer;
-      exports.isContextProvider = isContextProvider;
-      exports.isElement = isElement;
-      exports.isForwardRef = isForwardRef;
-      exports.isFragment = isFragment;
-      exports.isLazy = isLazy;
-      exports.isMemo = isMemo;
-      exports.isPortal = isPortal;
-      exports.isProfiler = isProfiler;
-      exports.isStrictMode = isStrictMode;
-      exports.isSuspense = isSuspense;
-      exports.isValidElementType = isValidElementType;
-      exports.typeOf = typeOf;
-    })();
+    module.exports = reactIs_production_min;
   }
 });
 
-var reactIs = createCommonjsModule(function (module) {
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
-  {
-    module.exports = reactIs_development;
-  }
-});
+var ReactPropTypesSecret$1 = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
+var ReactPropTypesSecret_1 = ReactPropTypesSecret$1;
 
-/*
-object-assign
-(c) Sindre Sorhus
-@license MIT
-*/
-/* eslint-disable no-unused-vars */
-
-var getOwnPropertySymbols = Object.getOwnPropertySymbols;
-var hasOwnProperty$3 = Object.prototype.hasOwnProperty;
-var propIsEnumerable = Object.prototype.propertyIsEnumerable;
-
-function toObject(val) {
-  if (val === null || val === undefined) {
-    throw new TypeError('Object.assign cannot be called with null or undefined');
-  }
-
-  return Object(val);
-}
-
-function shouldUseNative() {
-  try {
-    if (!Object.assign) {
-      return false;
-    } // Detect buggy property enumeration order in older V8 versions.
-    // https://bugs.chromium.org/p/v8/issues/detail?id=4118
-
-
-    var test1 = new String('abc'); // eslint-disable-line no-new-wrappers
-
-    test1[5] = 'de';
-
-    if (Object.getOwnPropertyNames(test1)[0] === '5') {
-      return false;
-    } // https://bugs.chromium.org/p/v8/issues/detail?id=3056
-
-
-    var test2 = {};
-
-    for (var i = 0; i < 10; i++) {
-      test2['_' + String.fromCharCode(i)] = i;
-    }
-
-    var order2 = Object.getOwnPropertyNames(test2).map(function (n) {
-      return test2[n];
-    });
-
-    if (order2.join('') !== '0123456789') {
-      return false;
-    } // https://bugs.chromium.org/p/v8/issues/detail?id=3056
-
-
-    var test3 = {};
-    'abcdefghijklmnopqrst'.split('').forEach(function (letter) {
-      test3[letter] = letter;
-    });
-
-    if (Object.keys(Object.assign({}, test3)).join('') !== 'abcdefghijklmnopqrst') {
-      return false;
-    }
-
-    return true;
-  } catch (err) {
-    // We don't expect any of the above to throw, but better to be safe.
-    return false;
-  }
-}
-
-var objectAssign = shouldUseNative() ? Object.assign : function (target, source) {
-  var from;
-  var to = toObject(target);
-  var symbols;
-
-  for (var s = 1; s < arguments.length; s++) {
-    from = Object(arguments[s]);
-
-    for (var key in from) {
-      if (hasOwnProperty$3.call(from, key)) {
-        to[key] = from[key];
-      }
-    }
-
-    if (getOwnPropertySymbols) {
-      symbols = getOwnPropertySymbols(from);
-
-      for (var i = 0; i < symbols.length; i++) {
-        if (propIsEnumerable.call(from, symbols[i])) {
-          to[symbols[i]] = from[symbols[i]];
-        }
-      }
-    }
-  }
-
-  return to;
-};
+var ReactPropTypesSecret = ReactPropTypesSecret_1;
 
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -6373,769 +6280,58 @@ var objectAssign = shouldUseNative() ? Object.assign : function (target, source)
  * LICENSE file in the root directory of this source tree.
  */
 
-var ReactPropTypesSecret$2 = 'SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED';
-var ReactPropTypesSecret_1 = ReactPropTypesSecret$2;
+function emptyFunction() {}
 
-var has$2 = Function.call.bind(Object.prototype.hasOwnProperty);
+function emptyFunctionWithReset() {}
 
-var ReactPropTypesSecret$1 = ReactPropTypesSecret_1;
+emptyFunctionWithReset.resetWarningCache = emptyFunction;
 
-var has$1 = has$2;
-
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-var _printWarning$1 = function printWarning() {};
-
-{
-  var ReactPropTypesSecret = ReactPropTypesSecret$1;
-  var loggedTypeFailures = {};
-  var has = has$1;
-
-  _printWarning$1 = function (text) {
-    var message = 'Warning: ' + text;
-
-    if (typeof console !== 'undefined') {
-      console.error(message);
+var factoryWithThrowingShims = function factoryWithThrowingShims() {
+  function shim(props, propName, componentName, location, propFullName, secret) {
+    if (secret === ReactPropTypesSecret) {
+      // It is still safe when called from React.
+      return;
     }
 
-    try {
-      // --- Welcome to debugging React ---
-      // This error was thrown as a convenience so that you can use this stack
-      // to find the callsite that caused this warning to fire.
-      throw new Error(message);
-    } catch (x) {
-      /**/
-    }
-  };
-}
-/**
- * Assert that the values match with the type specs.
- * Error messages are memorized and will only be shown once.
- *
- * @param {object} typeSpecs Map of name to a ReactPropType
- * @param {object} values Runtime values that need to be type-checked
- * @param {string} location e.g. "prop", "context", "child context"
- * @param {string} componentName Name of the component for error messages.
- * @param {?Function} getStack Returns the component stack.
- * @private
- */
-
-
-function checkPropTypes$1(typeSpecs, values, location, componentName, getStack) {
-  {
-    for (var typeSpecName in typeSpecs) {
-      if (has(typeSpecs, typeSpecName)) {
-        var error; // Prop type validation may throw. In case they do, we don't want to
-        // fail the render phase where it didn't fail before. So we log it.
-        // After these have been cleaned up, we'll let them throw.
-
-        try {
-          // This is intentionally an invariant that gets caught. It's the same
-          // behavior as without this statement except with a better message.
-          if (typeof typeSpecs[typeSpecName] !== 'function') {
-            var err = Error((componentName || 'React class') + ': ' + location + ' type `' + typeSpecName + '` is invalid; ' + 'it must be a function, usually from the `prop-types` package, but received `' + typeof typeSpecs[typeSpecName] + '`.' + 'This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.');
-            err.name = 'Invariant Violation';
-            throw err;
-          }
-
-          error = typeSpecs[typeSpecName](values, typeSpecName, componentName, location, null, ReactPropTypesSecret);
-        } catch (ex) {
-          error = ex;
-        }
-
-        if (error && !(error instanceof Error)) {
-          _printWarning$1((componentName || 'React class') + ': type specification of ' + location + ' `' + typeSpecName + '` is invalid; the type checker ' + 'function must return `null` or an `Error` but returned a ' + typeof error + '. ' + 'You may have forgotten to pass an argument to the type checker ' + 'creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and ' + 'shape all require an argument).');
-        }
-
-        if (error instanceof Error && !(error.message in loggedTypeFailures)) {
-          // Only monitor this failure once because there tends to be a lot of the
-          // same error.
-          loggedTypeFailures[error.message] = true;
-          var stack = getStack ? getStack() : '';
-
-          _printWarning$1('Failed ' + location + ' type: ' + error.message + (stack != null ? stack : ''));
-        }
-      }
-    }
+    var err = new Error('Calling PropTypes validators directly is not supported by the `prop-types` package. ' + 'Use PropTypes.checkPropTypes() to call them. ' + 'Read more at http://fb.me/use-check-prop-types');
+    err.name = 'Invariant Violation';
+    throw err;
   }
-}
-/**
- * Resets warning cache when testing.
- *
- * @private
- */
+  shim.isRequired = shim;
 
-
-checkPropTypes$1.resetWarningCache = function () {
-  {
-    loggedTypeFailures = {};
+  function getShim() {
+    return shim;
   }
-};
-
-var checkPropTypes_1 = checkPropTypes$1;
-
-var checkPropTypes = checkPropTypes_1;
-
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-var _printWarning = function printWarning() {};
-
-{
-  _printWarning = function (text) {
-    var message = 'Warning: ' + text;
-
-    if (typeof console !== 'undefined') {
-      console.error(message);
-    }
-
-    try {
-      // --- Welcome to debugging React ---
-      // This error was thrown as a convenience so that you can use this stack
-      // to find the callsite that caused this warning to fire.
-      throw new Error(message);
-    } catch (x) {}
-  };
-}
-
-function emptyFunctionThatReturnsNull() {
-  return null;
-}
-
-var factoryWithTypeCheckers = function factoryWithTypeCheckers(isValidElement, throwOnDirectAccess) {
-  /* global Symbol */
-  var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
-  var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
-
-  /**
-   * Returns the iterator method function contained on the iterable object.
-   *
-   * Be sure to invoke the function with the iterable as context:
-   *
-   *     var iteratorFn = getIteratorFn(myIterable);
-   *     if (iteratorFn) {
-   *       var iterator = iteratorFn.call(myIterable);
-   *       ...
-   *     }
-   *
-   * @param {?object} maybeIterable
-   * @return {?function}
-   */
-
-  function getIteratorFn(maybeIterable) {
-    var iteratorFn = maybeIterable && (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL] || maybeIterable[FAUX_ITERATOR_SYMBOL]);
-
-    if (typeof iteratorFn === 'function') {
-      return iteratorFn;
-    }
-  }
-  /**
-   * Collection of methods that allow declaration and validation of props that are
-   * supplied to React components. Example usage:
-   *
-   *   var Props = require('ReactPropTypes');
-   *   var MyArticle = React.createClass({
-   *     propTypes: {
-   *       // An optional string prop named "description".
-   *       description: Props.string,
-   *
-   *       // A required enum prop named "category".
-   *       category: Props.oneOf(['News','Photos']).isRequired,
-   *
-   *       // A prop named "dialog" that requires an instance of Dialog.
-   *       dialog: Props.instanceOf(Dialog).isRequired
-   *     },
-   *     render: function() { ... }
-   *   });
-   *
-   * A more formal specification of how these methods are used:
-   *
-   *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
-   *   decl := ReactPropTypes.{type}(.isRequired)?
-   *
-   * Each and every declaration produces a function with the same signature. This
-   * allows the creation of custom validation functions. For example:
-   *
-   *  var MyLink = React.createClass({
-   *    propTypes: {
-   *      // An optional string or URI prop named "href".
-   *      href: function(props, propName, componentName) {
-   *        var propValue = props[propName];
-   *        if (propValue != null && typeof propValue !== 'string' &&
-   *            !(propValue instanceof URI)) {
-   *          return new Error(
-   *            'Expected a string or an URI for ' + propName + ' in ' +
-   *            componentName
-   *          );
-   *        }
-   *      }
-   *    },
-   *    render: function() {...}
-   *  });
-   *
-   * @internal
-   */
-
-
-  var ANONYMOUS = '<<anonymous>>'; // Important!
-  // Keep this list in sync with production version in `./factoryWithThrowingShims.js`.
+  // Keep this list in sync with production version in `./factoryWithTypeCheckers.js`.
 
   var ReactPropTypes = {
-    array: createPrimitiveTypeChecker('array'),
-    bigint: createPrimitiveTypeChecker('bigint'),
-    bool: createPrimitiveTypeChecker('boolean'),
-    func: createPrimitiveTypeChecker('function'),
-    number: createPrimitiveTypeChecker('number'),
-    object: createPrimitiveTypeChecker('object'),
-    string: createPrimitiveTypeChecker('string'),
-    symbol: createPrimitiveTypeChecker('symbol'),
-    any: createAnyTypeChecker(),
-    arrayOf: createArrayOfTypeChecker,
-    element: createElementTypeChecker(),
-    elementType: createElementTypeTypeChecker(),
-    instanceOf: createInstanceTypeChecker,
-    node: createNodeChecker(),
-    objectOf: createObjectOfTypeChecker,
-    oneOf: createEnumTypeChecker,
-    oneOfType: createUnionTypeChecker,
-    shape: createShapeTypeChecker,
-    exact: createStrictShapeTypeChecker
+    array: shim,
+    bigint: shim,
+    bool: shim,
+    func: shim,
+    number: shim,
+    object: shim,
+    string: shim,
+    symbol: shim,
+    any: shim,
+    arrayOf: getShim,
+    element: shim,
+    elementType: shim,
+    instanceOf: getShim,
+    node: shim,
+    objectOf: getShim,
+    oneOf: getShim,
+    oneOfType: getShim,
+    shape: getShim,
+    exact: getShim,
+    checkPropTypes: emptyFunctionWithReset,
+    resetWarningCache: emptyFunction
   };
-  /**
-   * inlined Object.is polyfill to avoid requiring consumers ship their own
-   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
-   */
-
-  /*eslint-disable no-self-compare*/
-
-  function is(x, y) {
-    // SameValue algorithm
-    if (x === y) {
-      // Steps 1-5, 7-10
-      // Steps 6.b-6.e: +0 != -0
-      return x !== 0 || 1 / x === 1 / y;
-    } else {
-      // Step 6.a: NaN == NaN
-      return x !== x && y !== y;
-    }
-  }
-  /*eslint-enable no-self-compare*/
-
-  /**
-   * We use an Error-like object for backward compatibility as people may call
-   * PropTypes directly and inspect their output. However, we don't use real
-   * Errors anymore. We don't inspect their stack anyway, and creating them
-   * is prohibitively expensive if they are created too often, such as what
-   * happens in oneOfType() for any type before the one that matched.
-   */
-
-
-  function PropTypeError(message, data) {
-    this.message = message;
-    this.data = data && typeof data === 'object' ? data : {};
-    this.stack = '';
-  } // Make `instanceof Error` still work for returned errors.
-
-
-  PropTypeError.prototype = Error.prototype;
-
-  function createChainableTypeChecker(validate) {
-    {
-      var manualPropTypeCallCache = {};
-      var manualPropTypeWarningCount = 0;
-    }
-
-    function checkType(isRequired, props, propName, componentName, location, propFullName, secret) {
-      componentName = componentName || ANONYMOUS;
-      propFullName = propFullName || propName;
-
-      if (secret !== ReactPropTypesSecret$1) {
-        if (throwOnDirectAccess) {
-          // New behavior only for users of `prop-types` package
-          var err = new Error('Calling PropTypes validators directly is not supported by the `prop-types` package. ' + 'Use `PropTypes.checkPropTypes()` to call them. ' + 'Read more at http://fb.me/use-check-prop-types');
-          err.name = 'Invariant Violation';
-          throw err;
-        } else if (typeof console !== 'undefined') {
-          // Old behavior for people using React.PropTypes
-          var cacheKey = componentName + ':' + propName;
-
-          if (!manualPropTypeCallCache[cacheKey] && // Avoid spamming the console because they are often not actionable except for lib authors
-          manualPropTypeWarningCount < 3) {
-            _printWarning('You are manually calling a React.PropTypes validation ' + 'function for the `' + propFullName + '` prop on `' + componentName + '`. This is deprecated ' + 'and will throw in the standalone `prop-types` package. ' + 'You may be seeing this warning due to a third-party PropTypes ' + 'library. See https://fb.me/react-warning-dont-call-proptypes ' + 'for details.');
-
-            manualPropTypeCallCache[cacheKey] = true;
-            manualPropTypeWarningCount++;
-          }
-        }
-      }
-
-      if (props[propName] == null) {
-        if (isRequired) {
-          if (props[propName] === null) {
-            return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required ' + ('in `' + componentName + '`, but its value is `null`.'));
-          }
-
-          return new PropTypeError('The ' + location + ' `' + propFullName + '` is marked as required in ' + ('`' + componentName + '`, but its value is `undefined`.'));
-        }
-
-        return null;
-      } else {
-        return validate(props, propName, componentName, location, propFullName);
-      }
-    }
-
-    var chainedCheckType = checkType.bind(null, false);
-    chainedCheckType.isRequired = checkType.bind(null, true);
-    return chainedCheckType;
-  }
-
-  function createPrimitiveTypeChecker(expectedType) {
-    function validate(props, propName, componentName, location, propFullName, secret) {
-      var propValue = props[propName];
-      var propType = getPropType(propValue);
-
-      if (propType !== expectedType) {
-        // `propValue` being instance of, say, date/regexp, pass the 'object'
-        // check, but we can offer a more precise error message here rather than
-        // 'of type `object`'.
-        var preciseType = getPreciseType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + preciseType + '` supplied to `' + componentName + '`, expected ') + ('`' + expectedType + '`.'), {
-          expectedType: expectedType
-        });
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createAnyTypeChecker() {
-    return createChainableTypeChecker(emptyFunctionThatReturnsNull);
-  }
-
-  function createArrayOfTypeChecker(typeChecker) {
-    function validate(props, propName, componentName, location, propFullName) {
-      if (typeof typeChecker !== 'function') {
-        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside arrayOf.');
-      }
-
-      var propValue = props[propName];
-
-      if (!Array.isArray(propValue)) {
-        var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an array.'));
-      }
-
-      for (var i = 0; i < propValue.length; i++) {
-        var error = typeChecker(propValue, i, componentName, location, propFullName + '[' + i + ']', ReactPropTypesSecret$1);
-
-        if (error instanceof Error) {
-          return error;
-        }
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createElementTypeChecker() {
-    function validate(props, propName, componentName, location, propFullName) {
-      var propValue = props[propName];
-
-      if (!isValidElement(propValue)) {
-        var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement.'));
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createElementTypeTypeChecker() {
-    function validate(props, propName, componentName, location, propFullName) {
-      var propValue = props[propName];
-
-      if (!reactIs.isValidElementType(propValue)) {
-        var propType = getPropType(propValue);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected a single ReactElement type.'));
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createInstanceTypeChecker(expectedClass) {
-    function validate(props, propName, componentName, location, propFullName) {
-      if (!(props[propName] instanceof expectedClass)) {
-        var expectedClassName = expectedClass.name || ANONYMOUS;
-        var actualClassName = getClassName(props[propName]);
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + actualClassName + '` supplied to `' + componentName + '`, expected ') + ('instance of `' + expectedClassName + '`.'));
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createEnumTypeChecker(expectedValues) {
-    if (!Array.isArray(expectedValues)) {
-      {
-        if (arguments.length > 1) {
-          _printWarning('Invalid arguments supplied to oneOf, expected an array, got ' + arguments.length + ' arguments. ' + 'A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).');
-        } else {
-          _printWarning('Invalid argument supplied to oneOf, expected an array.');
-        }
-      }
-
-      return emptyFunctionThatReturnsNull;
-    }
-
-    function validate(props, propName, componentName, location, propFullName) {
-      var propValue = props[propName];
-
-      for (var i = 0; i < expectedValues.length; i++) {
-        if (is(propValue, expectedValues[i])) {
-          return null;
-        }
-      }
-
-      var valuesString = JSON.stringify(expectedValues, function replacer(key, value) {
-        var type = getPreciseType(value);
-
-        if (type === 'symbol') {
-          return String(value);
-        }
-
-        return value;
-      });
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of value `' + String(propValue) + '` ' + ('supplied to `' + componentName + '`, expected one of ' + valuesString + '.'));
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createObjectOfTypeChecker(typeChecker) {
-    function validate(props, propName, componentName, location, propFullName) {
-      if (typeof typeChecker !== 'function') {
-        return new PropTypeError('Property `' + propFullName + '` of component `' + componentName + '` has invalid PropType notation inside objectOf.');
-      }
-
-      var propValue = props[propName];
-      var propType = getPropType(propValue);
-
-      if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type ' + ('`' + propType + '` supplied to `' + componentName + '`, expected an object.'));
-      }
-
-      for (var key in propValue) {
-        if (has$1(propValue, key)) {
-          var error = typeChecker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret$1);
-
-          if (error instanceof Error) {
-            return error;
-          }
-        }
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createUnionTypeChecker(arrayOfTypeCheckers) {
-    if (!Array.isArray(arrayOfTypeCheckers)) {
-      _printWarning('Invalid argument supplied to oneOfType, expected an instance of array.') ;
-      return emptyFunctionThatReturnsNull;
-    }
-
-    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
-      var checker = arrayOfTypeCheckers[i];
-
-      if (typeof checker !== 'function') {
-        _printWarning('Invalid argument supplied to oneOfType. Expected an array of check functions, but ' + 'received ' + getPostfixForTypeWarning(checker) + ' at index ' + i + '.');
-
-        return emptyFunctionThatReturnsNull;
-      }
-    }
-
-    function validate(props, propName, componentName, location, propFullName) {
-      var expectedTypes = [];
-
-      for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
-        var checker = arrayOfTypeCheckers[i];
-        var checkerResult = checker(props, propName, componentName, location, propFullName, ReactPropTypesSecret$1);
-
-        if (checkerResult == null) {
-          return null;
-        }
-
-        if (checkerResult.data && has$1(checkerResult.data, 'expectedType')) {
-          expectedTypes.push(checkerResult.data.expectedType);
-        }
-      }
-
-      var expectedTypesMessage = expectedTypes.length > 0 ? ', expected one of type [' + expectedTypes.join(', ') + ']' : '';
-      return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`' + expectedTypesMessage + '.'));
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createNodeChecker() {
-    function validate(props, propName, componentName, location, propFullName) {
-      if (!isNode(props[propName])) {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` supplied to ' + ('`' + componentName + '`, expected a ReactNode.'));
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function invalidValidatorError(componentName, location, propFullName, key, type) {
-    return new PropTypeError((componentName || 'React class') + ': ' + location + ' type `' + propFullName + '.' + key + '` is invalid; ' + 'it must be a function, usually from the `prop-types` package, but received `' + type + '`.');
-  }
-
-  function createShapeTypeChecker(shapeTypes) {
-    function validate(props, propName, componentName, location, propFullName) {
-      var propValue = props[propName];
-      var propType = getPropType(propValue);
-
-      if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
-      }
-
-      for (var key in shapeTypes) {
-        var checker = shapeTypes[key];
-
-        if (typeof checker !== 'function') {
-          return invalidValidatorError(componentName, location, propFullName, key, getPreciseType(checker));
-        }
-
-        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret$1);
-
-        if (error) {
-          return error;
-        }
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function createStrictShapeTypeChecker(shapeTypes) {
-    function validate(props, propName, componentName, location, propFullName) {
-      var propValue = props[propName];
-      var propType = getPropType(propValue);
-
-      if (propType !== 'object') {
-        return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` of type `' + propType + '` ' + ('supplied to `' + componentName + '`, expected `object`.'));
-      } // We need to check all keys in case some are required but missing from props.
-
-
-      var allKeys = objectAssign({}, props[propName], shapeTypes);
-
-      for (var key in allKeys) {
-        var checker = shapeTypes[key];
-
-        if (has$1(shapeTypes, key) && typeof checker !== 'function') {
-          return invalidValidatorError(componentName, location, propFullName, key, getPreciseType(checker));
-        }
-
-        if (!checker) {
-          return new PropTypeError('Invalid ' + location + ' `' + propFullName + '` key `' + key + '` supplied to `' + componentName + '`.' + '\nBad object: ' + JSON.stringify(props[propName], null, '  ') + '\nValid keys: ' + JSON.stringify(Object.keys(shapeTypes), null, '  '));
-        }
-
-        var error = checker(propValue, key, componentName, location, propFullName + '.' + key, ReactPropTypesSecret$1);
-
-        if (error) {
-          return error;
-        }
-      }
-
-      return null;
-    }
-
-    return createChainableTypeChecker(validate);
-  }
-
-  function isNode(propValue) {
-    switch (typeof propValue) {
-      case 'number':
-      case 'string':
-      case 'undefined':
-        return true;
-
-      case 'boolean':
-        return !propValue;
-
-      case 'object':
-        if (Array.isArray(propValue)) {
-          return propValue.every(isNode);
-        }
-
-        if (propValue === null || isValidElement(propValue)) {
-          return true;
-        }
-
-        var iteratorFn = getIteratorFn(propValue);
-
-        if (iteratorFn) {
-          var iterator = iteratorFn.call(propValue);
-          var step;
-
-          if (iteratorFn !== propValue.entries) {
-            while (!(step = iterator.next()).done) {
-              if (!isNode(step.value)) {
-                return false;
-              }
-            }
-          } else {
-            // Iterator will provide entry [k,v] tuples rather than values.
-            while (!(step = iterator.next()).done) {
-              var entry = step.value;
-
-              if (entry) {
-                if (!isNode(entry[1])) {
-                  return false;
-                }
-              }
-            }
-          }
-        } else {
-          return false;
-        }
-
-        return true;
-
-      default:
-        return false;
-    }
-  }
-
-  function isSymbol(propType, propValue) {
-    // Native Symbol.
-    if (propType === 'symbol') {
-      return true;
-    } // falsy value can't be a Symbol
-
-
-    if (!propValue) {
-      return false;
-    } // 19.4.3.5 Symbol.prototype[@@toStringTag] === 'Symbol'
-
-
-    if (propValue['@@toStringTag'] === 'Symbol') {
-      return true;
-    } // Fallback for non-spec compliant Symbols which are polyfilled.
-
-
-    if (typeof Symbol === 'function' && propValue instanceof Symbol) {
-      return true;
-    }
-
-    return false;
-  } // Equivalent of `typeof` but with special handling for array and regexp.
-
-
-  function getPropType(propValue) {
-    var propType = typeof propValue;
-
-    if (Array.isArray(propValue)) {
-      return 'array';
-    }
-
-    if (propValue instanceof RegExp) {
-      // Old webkits (at least until Android 4.0) return 'function' rather than
-      // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
-      // passes PropTypes.object.
-      return 'object';
-    }
-
-    if (isSymbol(propType, propValue)) {
-      return 'symbol';
-    }
-
-    return propType;
-  } // This handles more types than `getPropType`. Only used for error messages.
-  // See `createPrimitiveTypeChecker`.
-
-
-  function getPreciseType(propValue) {
-    if (typeof propValue === 'undefined' || propValue === null) {
-      return '' + propValue;
-    }
-
-    var propType = getPropType(propValue);
-
-    if (propType === 'object') {
-      if (propValue instanceof Date) {
-        return 'date';
-      } else if (propValue instanceof RegExp) {
-        return 'regexp';
-      }
-    }
-
-    return propType;
-  } // Returns a string that is postfixed to a warning about an invalid type.
-  // For example, "undefined" or "of type array"
-
-
-  function getPostfixForTypeWarning(value) {
-    var type = getPreciseType(value);
-
-    switch (type) {
-      case 'array':
-      case 'object':
-        return 'an ' + type;
-
-      case 'boolean':
-      case 'date':
-      case 'regexp':
-        return 'a ' + type;
-
-      default:
-        return type;
-    }
-  } // Returns class name of the object, if any.
-
-
-  function getClassName(propValue) {
-    if (!propValue.constructor || !propValue.constructor.name) {
-      return ANONYMOUS;
-    }
-
-    return propValue.constructor.name;
-  }
-
-  ReactPropTypes.checkPropTypes = checkPropTypes;
-  ReactPropTypes.resetWarningCache = checkPropTypes.resetWarningCache;
   ReactPropTypes.PropTypes = ReactPropTypes;
   return ReactPropTypes;
 };
 
-var require$$1 = factoryWithTypeCheckers;
+var require$$2 = factoryWithThrowingShims;
 
 /**
  * Copyright (c) 2013-present, Facebook, Inc.
@@ -7145,11 +6341,9 @@ var require$$1 = factoryWithTypeCheckers;
  */
 var propTypes = createCommonjsModule(function (module) {
   {
-    var ReactIs = reactIs; // By explicitly using `prop-types` you are opting into new development behavior.
+    // By explicitly using `prop-types` you are opting into new production behavior.
     // http://fb.me/prop-types-in-prod
-
-    var throwOnDirectAccess = true;
-    module.exports = require$$1(ReactIs.isElement, throwOnDirectAccess);
+    module.exports = require$$2();
   }
 });
 var PropTypes = propTypes;
@@ -7419,7 +6613,7 @@ function convert(createElement, element) {
 var PRODUCTION = false;
 
 try {
-  PRODUCTION = "development" === 'production';
+  PRODUCTION = "production" === 'production';
 } catch (e) {}
 
 function log() {
@@ -12896,7 +12090,7 @@ function RoundedButton(_ref) {
   } = _ref,
       props = _objectWithoutPropertiesLoose(_ref, _excluded$5);
 
-  return /*#__PURE__*/React__default.createElement("button", _extends({
+  return React__default.createElement("button", _extends({
     type: props.type || 'button',
     className: `w-6 h-6 rounded-full flex items-center justify-center
             text-xs ~bg-white text-indigo-500 hover:~text-indigo-600 
@@ -12917,20 +12111,20 @@ function FrameCodeSnippetLine({
     file: frame.file,
     lineNumber
   });
-  return /*#__PURE__*/React__default.createElement("span", {
+  return React__default.createElement("span", {
     className: `
                 flex group leading-loose hover:~bg-red-500/10
                 ${highlight ? ' ~bg-red-500/20' : ''}
             `
-  }, editorUrl && /*#__PURE__*/React__default.createElement("span", {
+  }, editorUrl && React__default.createElement("span", {
     className: "z-30 opacity-0 group-hover:opacity-100 sticky left-10 w-0 h-full"
-  }, /*#__PURE__*/React__default.createElement("a", {
+  }, React__default.createElement("a", {
     href: editorUrl,
     className: "-ml-3 block"
-  }, /*#__PURE__*/React__default.createElement(RoundedButton, null, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(RoundedButton, null, React__default.createElement(FontAwesomeIcon, {
     className: "text-xs",
     icon: faPencilAlt
-  })))), /*#__PURE__*/React__default.createElement("span", {
+  })))), React__default.createElement("span", {
     className: "pl-6"
   }, createElement({
     node: row,
@@ -13051,7 +12245,7 @@ function FrameCodeSnippet({
   const codeRenderer = useMemo(() => ({
     rows
   }) => {
-    return rows.map((row, index) => /*#__PURE__*/React__default.createElement(FrameCodeSnippetLine, {
+    return rows.map((row, index) => React__default.createElement(FrameCodeSnippetLine, {
       key: lineNumbers[index],
       frame: frame,
       highlight: index === highlightedIndex,
@@ -13059,23 +12253,23 @@ function FrameCodeSnippet({
       lineNumber: lineNumbers[index]
     }));
   }, [frame]);
-  return /*#__PURE__*/React__default.createElement("main", {
+  return React__default.createElement("main", {
     className: "flex items-stretch flex-grow overflow-x-auto overflow-y-hidden scrollbar-hidden-x mask-fade-r text-sm"
-  }, /*#__PURE__*/React__default.createElement("nav", {
+  }, React__default.createElement("nav", {
     className: "sticky left-0 flex flex-none z-20 ~bg-white"
-  }, /*#__PURE__*/React__default.createElement("div", {
-    className: "select-none"
-  }, lineNumbers.map(number => /*#__PURE__*/React__default.createElement("p", {
+  }, React__default.createElement("div", {
+    className: "select-none text-right"
+  }, lineNumbers.map(number => React__default.createElement("p", {
     key: number,
     className: `
                                 px-2 font-mono leading-loose select-none
                                 ${Number(number) === frame.line_number ? ' text-opacity-75 ~text-red-700 ~bg-red-500/30' : ''}
                             `
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     className: "~text-gray-500"
-  }, number))))), /*#__PURE__*/React__default.createElement("div", {
+  }, number))))), React__default.createElement("div", {
     className: "flex-grow pr-10"
-  }, /*#__PURE__*/React__default.createElement(SyntaxHighlighter$1, {
+  }, React__default.createElement(SyntaxHighlighter$1, {
     language: getLanguage(frame.relative_file),
     renderer: codeRenderer,
     customStyle: {
@@ -13514,15 +12708,15 @@ function RelaxedFullyQualifiedClassName({
 }) {
   const parts = path.split('\\');
   const tightSpace = String.fromCharCode(8201);
-  return /*#__PURE__*/React__default.createElement("span", {
+  return React__default.createElement("span", {
     className: "inline-flex flex-wrap items-baseline"
-  }, parts.map((part, index) => /*#__PURE__*/React__default.createElement(React__default.Fragment, {
+  }, parts.map((part, index) => React__default.createElement(React__default.Fragment, {
     key: index
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     key: index
-  }, part), index !== parts.length - 1 && /*#__PURE__*/React__default.createElement("span", null, tightSpace, "\\", tightSpace))), lineNumber && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, tightSpace, /*#__PURE__*/React__default.createElement("span", {
+  }, part), index !== parts.length - 1 && React__default.createElement("span", null, tightSpace, "\\", tightSpace))), lineNumber && React__default.createElement(React__default.Fragment, null, tightSpace, React__default.createElement("span", {
     className: "whitespace-nowrap"
-  }, ":", tightSpace, /*#__PURE__*/React__default.createElement("span", {
+  }, ":", tightSpace, React__default.createElement("span", {
     className: "font-mono text-xs"
   }, lineNumber))));
 }
@@ -13542,17 +12736,17 @@ function RelaxedFilePath({
   const extension = fileParts.pop();
   const fileName = fileParts.join('.');
   const tightSpace = String.fromCharCode(8201);
-  return /*#__PURE__*/React__default.createElement("span", {
+  return React__default.createElement("span", {
     className: "inline-flex flex-wrap items-baseline"
-  }, parts.map((part, index) => /*#__PURE__*/React__default.createElement(React__default.Fragment, {
+  }, parts.map((part, index) => React__default.createElement(React__default.Fragment, {
     key: index
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     key: index
-  }, part), /*#__PURE__*/React__default.createElement("span", null, tightSpace, "/", tightSpace))), /*#__PURE__*/React__default.createElement("span", {
+  }, part), React__default.createElement("span", null, tightSpace, "/", tightSpace))), React__default.createElement("span", {
     className: "font-semibold"
-  }, fileName), /*#__PURE__*/React__default.createElement("span", null, ".", extension), lineNumber && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, tightSpace, /*#__PURE__*/React__default.createElement("span", {
+  }, fileName), React__default.createElement("span", null, ".", extension), lineNumber && React__default.createElement(React__default.Fragment, null, tightSpace, React__default.createElement("span", {
     className: "whitespace-nowrap"
-  }, ":", tightSpace, /*#__PURE__*/React__default.createElement("span", {
+  }, ":", tightSpace, React__default.createElement("span", {
     className: "font-mono text-xs"
   }, lineNumber))));
 }
@@ -13563,34 +12757,34 @@ function FrameGroup({
   onSelect
 }) {
   if (frameGroup.type === 'vendor' && !frameGroup.expanded) {
-    return /*#__PURE__*/React__default.createElement("li", {
+    return React__default.createElement("li", {
       className: "group cursor-pointer px-6 sm:px-10 py-4 flex gap-2 lg:justify-start border-b ~border-gray-200 hover:~bg-gray-500/5 items-center",
       onClick: onExpand
-    }, frameGroup.frames.length > 1 ? `${frameGroup.frames.length} vendor frames` : '1 vendor frame', /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    }, frameGroup.frames.length > 1 ? `${frameGroup.frames.length} vendor frames` : '1 vendor frame', React__default.createElement(FontAwesomeIcon, {
       icon: faAngleDown,
       className: "~text-gray-500 group-hover:text-indigo-500"
     }));
   }
 
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, frameGroup.frames.map((frame, index) => /*#__PURE__*/React__default.createElement(React__default.Fragment, {
+  return React__default.createElement(React__default.Fragment, null, frameGroup.frames.map((frame, index) => React__default.createElement(React__default.Fragment, {
     key: index
-  }, /*#__PURE__*/React__default.createElement("li", {
+  }, React__default.createElement("li", {
     key: frame.frame_number,
     className: `px-6 sm:px-10 py-4
                             ${frame.selected ? 'bg-red-500 text-white' : 'cursor-pointer border-b ~border-gray-200 hover:~bg-red-500/10'}
                         `,
     onClick: () => onSelect(frame.frame_number)
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex items-baseline"
-  }, frame.class ? /*#__PURE__*/React__default.createElement(RelaxedFullyQualifiedClassName, {
+  }, frame.class ? React__default.createElement(RelaxedFullyQualifiedClassName, {
     path: frame.class,
     lineNumber: frame.line_number
-  }) : /*#__PURE__*/React__default.createElement(RelaxedFilePath, {
+  }) : React__default.createElement(RelaxedFilePath, {
     path: frame.file,
     lineNumber: frame.line_number
-  })), /*#__PURE__*/React__default.createElement("div", {
+  })), React__default.createElement("div", {
     className: "font-semibold"
-  }, frame.method)), frame.selected && /*#__PURE__*/React__default.createElement("li", {
+  }, frame.method)), frame.selected && React__default.createElement("li", {
     className: "z-10 mt-[-4px] sticky top-0 bg-red-500 h-[4px]"
   }))));
 }
@@ -13604,10 +12798,10 @@ function EditorLink({
     file: path,
     lineNumber
   });
-  return /*#__PURE__*/React__default.createElement("a", {
+  return React__default.createElement("a", {
     href: editorUrl || '#',
     className: `hover:underline ${className}`
-  }, /*#__PURE__*/React__default.createElement(RelaxedFilePath, {
+  }, React__default.createElement(RelaxedFilePath, {
     path: path,
     lineNumber: lineNumber
   }));
@@ -13860,7 +13054,7 @@ function SmallButton(_ref) {
   } = _ref,
       props = _objectWithoutPropertiesLoose(_ref, _excluded$4);
 
-  return /*#__PURE__*/React__default.createElement("button", _extends({
+  return React__default.createElement("button", _extends({
     type: props.type || 'button',
     className: `group inline-flex gap-2 items-center h-6 px-2 rounded-sm ~bg-white shadow text-xs font-medium whitespace-nowrap
             transform
@@ -13913,32 +13107,32 @@ function StackTrace({
       type: 'SELECT_PREVIOUS_FRAME'
     });
   });
-  return /*#__PURE__*/React__default.createElement("div", {
-    className: "grid grid-cols-1 lg:grid-cols-[33.33%,66.66%] lg:grid-rows-[57rem] items-stretch shadow-lg ~bg-white overflow-hidden"
-  }, /*#__PURE__*/React__default.createElement("aside", {
+  return React__default.createElement("div", {
+    className: "grid grid-cols-1 lg:grid-cols-[33.33%,66.66%] lg:grid-rows-[57rem] items-stretch bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 overflow-hidden"
+  }, React__default.createElement("aside", {
     className: "z-30 flex flex-col border-r ~border-gray-200"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "max-h-[33vh] lg:max-h-[none] lg:absolute inset-0 flex flex-col overflow-hidden ~bg-white"
-  }, /*#__PURE__*/React__default.createElement("header", {
+  }, React__default.createElement("header", {
     className: "flex-none px-6 sm:px-10 h-16 flex items-center justify-start ~bg-white border-b ~border-gray-200"
-  }, /*#__PURE__*/React__default.createElement(SmallButton, {
+  }, React__default.createElement(SmallButton, {
     onClick: () => dispatch({
       type: vendorFramesExpanded ? 'COLLAPSE_ALL_VENDOR_FRAMES' : 'EXPAND_ALL_VENDOR_FRAMES'
     })
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: `flex ${vendorFramesExpanded ? 'flex-col-reverse' : 'flex-col'}`
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faAngleUp,
     className: "-my-px text-[8px] ~text-gray-500 group-hover:text-indigo-500"
-  }), /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }), React__default.createElement(FontAwesomeIcon, {
     icon: faAngleDown,
     className: "-my-px text-[8px] ~text-gray-500 group-hover:text-indigo-500"
-  })), vendorFramesExpanded ? 'Collapse vendor frames' : ' Expand vendor frames')), /*#__PURE__*/React__default.createElement("div", {
+  })), vendorFramesExpanded ? 'Collapse vendor frames' : ' Expand vendor frames')), React__default.createElement("div", {
     id: "frames",
     className: "flex-grow overflow-auto scrollbar-hidden-y mask-fade-frames"
-  }, /*#__PURE__*/React__default.createElement("ol", {
+  }, React__default.createElement("ol", {
     className: "text-sm pb-16"
-  }, frameGroups.map((frameGroup, i) => /*#__PURE__*/React__default.createElement(FrameGroup, {
+  }, frameGroups.map((frameGroup, i) => React__default.createElement(FrameGroup, {
     key: i,
     frameGroup: frameGroup,
     onExpand: () => dispatch({
@@ -13951,15 +13145,15 @@ function StackTrace({
         frame: frameNumber
       });
     }
-  })))))), /*#__PURE__*/React__default.createElement("section", {
+  })))))), React__default.createElement("section", {
     className: "flex flex-col border-t lg:border-t-0 ~border-gray-200"
-  }, selectedFrame && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement("header", {
+  }, selectedFrame && React__default.createElement(React__default.Fragment, null, React__default.createElement("header", {
     className: "~text-gray-500 flex-none z-30 h-16 px-6 sm:px-10 flex items-center justify-end"
-  }, /*#__PURE__*/React__default.createElement(EditorLink, {
+  }, React__default.createElement(EditorLink, {
     path: selectedFrame.file,
     lineNumber: selectedFrame.line_number,
     className: "flex items-center text-sm"
-  })), /*#__PURE__*/React__default.createElement(FrameCodeSnippet, {
+  })), React__default.createElement(FrameCodeSnippet, {
     frame: selectedFrame
   }))));
 }
@@ -13981,13 +13175,13 @@ function ExceptionMessage({
     setFullException(!fullException);
   }
 
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: `
                 my-4 font-semibold leading-snug text-xl
                 ${className}
             `,
     onClick: handleClick
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: fullException ? 'line-clamp-none' : 'line-clamp-2'
   }, message));
 }
@@ -17383,18 +16577,18 @@ function CopyButton({
     setCopied(true);
   }
 
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: className
-  }, /*#__PURE__*/React__default.createElement(RoundedButton, {
+  }, React__default.createElement(RoundedButton, {
     onClick: copy,
     title: "Copy to clipboard",
     className: `
                     ${alwaysVisible ? '' : 'opacity-0 transform scale-80 transition-animation delay-100'}
                     ${copied ? 'opacity-0' : 'group-hover:opacity-100 group-hover:scale-100'}
                 `
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faCopy
-  })), copied && /*#__PURE__*/React__default.createElement("p", {
+  })), copied && React__default.createElement("p", {
     className: `absolute top-0 ${direction == 'right' ? 'right-0' : 'left-0'} hidden z-10 sm:inline-flex gap-2 items-center h-6 px-2 rounded-sm ~bg-white shadow text-xs font-medium whitespace-nowrap text-emerald-500`,
     onClick: () => setCopied(false)
   }, "Copied!"));
@@ -17483,7 +16677,7 @@ function HighlightedCode({
   children,
   language
 }) {
-  return /*#__PURE__*/React__default.createElement(SyntaxHighlighter$1, {
+  return React__default.createElement(SyntaxHighlighter$1, {
     language: language,
     customStyle: {
       background: 'transparent'
@@ -17537,30 +16731,30 @@ function CodeSnippet({
     selection.addRange(range);
   }
 
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     ref: containerRef,
     className: `
                 ${isOverflowing ? 'cursor-pointer' : ''}
                 ${transparent ? '' : '~bg-gray-500/5'}
                 group py-2`,
     onClick: handleClick
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: `${overflowX ? 'mask-fade-x' : ''}`
-  }, language === 'sql' && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, isCollapsed ? /*#__PURE__*/React__default.createElement("pre", {
+  }, language === 'sql' && React__default.createElement(React__default.Fragment, null, isCollapsed ? React__default.createElement("pre", {
     className: `pl-4 ${overflowX ? 'overflow-x-scroll scrollbar-hidden-x pr-12' : 'truncate pr-8'}`
-  }, /*#__PURE__*/React__default.createElement("code", {
+  }, React__default.createElement("code", {
     className: "font-mono leading-relaxed text-sm font-normal"
-  }, /*#__PURE__*/React__default.createElement(HighlightedCode, {
+  }, React__default.createElement(HighlightedCode, {
     language: "sql"
-  }, value))) : /*#__PURE__*/React__default.createElement("pre", {
+  }, value))) : React__default.createElement("pre", {
     className: `pl-4 ${overflowX ? 'overflow-x-scroll scrollbar-hidden-x pr-12' : 'pr-8'}`
-  }, /*#__PURE__*/React__default.createElement("code", {
+  }, React__default.createElement("code", {
     className: "font-mono leading-relaxed text-sm font-normal"
-  }, /*#__PURE__*/React__default.createElement(HighlightedCode, {
+  }, React__default.createElement(HighlightedCode, {
     language: "sql"
   }, sqlFormatter$1.format(value, {
     language: 'mysql'
-  }))))), language !== 'sql' && /*#__PURE__*/React__default.createElement("pre", {
+  }))))), language !== 'sql' && React__default.createElement("pre", {
     ref: ref,
     className: `
                             pl-4
@@ -17568,17 +16762,17 @@ function CodeSnippet({
                             ${isCollapsed ? 'overflow-y-hidden max-h-32' : ''}
                             ${overflowX ? 'overflow-x-scroll scrollbar-hidden-x pr-12' : 'pr-8'}
                         `
-  }, /*#__PURE__*/React__default.createElement("code", {
+  }, React__default.createElement("code", {
     className: "font-mono leading-relaxed text-sm font-normal"
-  }, language ? /*#__PURE__*/React__default.createElement(HighlightedCode, {
+  }, language ? React__default.createElement(HighlightedCode, {
     language: language
-  }, value) : value))), /*#__PURE__*/React__default.createElement(CopyButton, {
+  }, value) : value))), React__default.createElement(CopyButton, {
     className: "absolute top-2 right-3",
     value: value
-  }), isOverflowing && /*#__PURE__*/React__default.createElement(RoundedButton, {
+  }), isOverflowing && React__default.createElement(RoundedButton, {
     onClick: () => setIsCollapsed(!isCollapsed),
-    className: " absolute -bottom-3 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 scale-80 group-hover:scale-100 delay-100 "
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    className: "\n                        absolute -bottom-3 left-1/2 -translate-x-1/2\n                        opacity-0 group-hover:opacity-100 scale-80 group-hover:scale-100 delay-100\n                    "
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faAngleDown,
     className: `transition-transform duration-300 transform ${isCollapsed ? '' : 'rotate-180'}`
   })));
@@ -17602,10 +16796,10 @@ function FormattedExceptionMessage({
       setCleanedUpMessage(message.replace(sqlQueryPattern, '$2'));
     }
   }, [message, exceptionClass]);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement(ExceptionMessage, {
+  return React__default.createElement(React__default.Fragment, null, React__default.createElement(ExceptionMessage, {
     message: cleanedUpMessage,
     className: className
-  }), sqlQuery && /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }), sqlQuery && React__default.createElement(CodeSnippet, {
     value: sqlQuery,
     language: "sql"
   }));
@@ -17620,7 +16814,7 @@ function Button(_ref) {
   } = _ref,
       props = _objectWithoutPropertiesLoose(_ref, _excluded$3);
 
-  return /*#__PURE__*/React__default.createElement("button", _extends({
+  return React__default.createElement("button", _extends({
     disabled: disabled,
     className: `px-4 h-8 whitespace-nowrap border-b
             text-xs uppercase tracking-wider font-bold rounded-sm
@@ -17639,13 +16833,13 @@ function Button(_ref) {
 function SolutionDescription({
   solution
 }) {
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: "grid grid-cols-1 gap-2"
-  }, solution.description && /*#__PURE__*/React__default.createElement("p", null, solution.description), solution.action_description && /*#__PURE__*/React__default.createElement("p", null, solution.action_description), /*#__PURE__*/React__default.createElement("ul", {
+  }, solution.description && React__default.createElement("p", null, solution.description), solution.action_description && React__default.createElement("p", null, solution.action_description), React__default.createElement("ul", {
     className: "grid grid-cols-1 gap-1 text-sm"
-  }, Object.entries(solution.links).map(([title, link], index) => /*#__PURE__*/React__default.createElement("li", {
+  }, Object.entries(solution.links).map(([title, link], index) => React__default.createElement("li", {
     key: index
-  }, /*#__PURE__*/React__default.createElement("a", {
+  }, React__default.createElement("a", {
     href: link,
     target: "_blank",
     className: "underline text-emerald-700 hover:text-emerald-800"
@@ -17695,31 +16889,31 @@ function SolutionRunner({
     location.reload();
   }
 
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, wasExecutionSuccessful === null && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement(Button, {
+  return React__default.createElement(React__default.Fragment, null, wasExecutionSuccessful === null && React__default.createElement(React__default.Fragment, null, React__default.createElement(Button, {
     onClick: executeSolution,
     disabled: isRunningSolution,
     className: "mb-4 inline-flex items-center gap-2 bg-emerald-600 border-emerald-500/25 text-white"
-  }, isRunningSolution ? /*#__PURE__*/React__default.createElement("span", null, "Running...") : /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, isRunningSolution ? React__default.createElement("span", null, "Running...") : React__default.createElement(React__default.Fragment, null, React__default.createElement(FontAwesomeIcon, {
     className: "opacity-50",
     icon: faWrench
-  }), solution.run_button_text || 'Run')), /*#__PURE__*/React__default.createElement(SolutionDescription, {
+  }), solution.run_button_text || 'Run')), React__default.createElement(SolutionDescription, {
     solution: solution
-  })), wasExecutionSuccessful === true && /*#__PURE__*/React__default.createElement("p", {
+  })), wasExecutionSuccessful === true && React__default.createElement("p", {
     className: ""
-  }, "The solution was executed ", /*#__PURE__*/React__default.createElement("strong", null, "successfully"), ".", /*#__PURE__*/React__default.createElement("br", null), /*#__PURE__*/React__default.createElement("a", {
+  }, "The solution was executed ", React__default.createElement("strong", null, "successfully"), ".", React__default.createElement("br", null), React__default.createElement("a", {
     href: "#",
     className: "mt-2 inline-flex items-center gap-2 underline text-emerald-700 hover:text-emerald-800",
     onClick: refresh
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faRedoAlt,
     className: "text-sm opacity-50"
-  }), "Refresh now")), wasExecutionSuccessful === false && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement("p", {
+  }), "Refresh now")), wasExecutionSuccessful === false && React__default.createElement(React__default.Fragment, null, React__default.createElement("p", {
     className: "bg-red-200 px-4 py-2"
-  }, "Something ", /*#__PURE__*/React__default.createElement("strong", null, "went wrong"), ". Please try refreshing the page and try again.", /*#__PURE__*/React__default.createElement("br", null), /*#__PURE__*/React__default.createElement("a", {
+  }, "Something ", React__default.createElement("strong", null, "went wrong"), ". Please try refreshing the page and try again.", React__default.createElement("br", null), React__default.createElement("a", {
     href: "#",
     className: "mt-2 inline-flex items-center gap-2 underline text-red-700 hover:text-red-800",
     onClick: refresh
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faRedoAlt,
     className: "text-sm opacity-50"
   }), "Refresh now"))));
@@ -17732,27 +16926,27 @@ function Solution({
   canExecute = false
 }) {
   const [isOpen, setIsOpen] = useState(initialIsOpen);
-  return /*#__PURE__*/React__default.createElement("section", null, /*#__PURE__*/React__default.createElement("header", {
+  return React__default.createElement("section", null, React__default.createElement("header", {
     className: "group mb-4"
-  }, isCollapsible ? /*#__PURE__*/React__default.createElement("button", {
+  }, isCollapsible ? React__default.createElement("button", {
     className: "flex items-center justify-start",
     onClick: () => {
       setIsOpen(!isOpen);
     }
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     className: "w-6 -ml-6"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faAngleDown,
     className: `group-hover:opacity-50 opacity-0 text-sm transform transition ${isOpen ? '' : '-rotate-90'}`
-  })), /*#__PURE__*/React__default.createElement("h2", {
+  })), React__default.createElement("h2", {
     className: "min-w-0 truncate font-semibold leading-snug"
-  }, solution.title)) : /*#__PURE__*/React__default.createElement("h2", {
+  }, solution.title)) : React__default.createElement("h2", {
     className: "truncate font-semibold leading-snug"
-  }, solution.title)), /*#__PURE__*/React__default.createElement("div", {
+  }, solution.title)), React__default.createElement("div", {
     className: `${isOpen ? '' : 'hidden'}`
-  }, solution.is_runnable && canExecute ? /*#__PURE__*/React__default.createElement(SolutionRunner, {
+  }, solution.is_runnable && canExecute ? React__default.createElement(SolutionRunner, {
     solution: solution
-  }) : /*#__PURE__*/React__default.createElement(SolutionDescription, {
+  }) : React__default.createElement(SolutionDescription, {
     solution: solution
   })));
 }
@@ -17780,29 +16974,29 @@ function Solutions() {
       setCanExecuteSolutions(false);
     }
   }, []);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, showSolutions ? /*#__PURE__*/React__default.createElement("aside", {
+  return React__default.createElement(React__default.Fragment, null, showSolutions ? React__default.createElement("aside", {
     id: "solution",
     className: "flex flex-col lg:w-2/5 flex-none"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex-grow px-6 sm:px-10 py-8 bg-emerald-300 text-gray-800"
-  }, /*#__PURE__*/React__default.createElement("button", {
+  }, React__default.createElement("button", {
     onClick: () => setShowSolutions(false),
     className: "absolute top-3 right-4 leading-none text-emerald-500 hover:text-emerald-700 text-sm"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faTimes
-  })), solutions.map((solution, index) => /*#__PURE__*/React__default.createElement("div", {
+  })), solutions.map((solution, index) => React__default.createElement("div", {
     key: index
-  }, /*#__PURE__*/React__default.createElement(Solution, {
+  }, React__default.createElement(Solution, {
     solution: solution,
     canExecute: canExecuteSolutions,
     isOpen: index === 0,
     isCollapsible: solutions.length > 1
-  }), index !== solutions.length - 1 && /*#__PURE__*/React__default.createElement("hr", {
+  }), index !== solutions.length - 1 && React__default.createElement("hr", {
     className: "my-4 border-t border-gray-800/20"
-  }))))) : /*#__PURE__*/React__default.createElement("button", {
+  }))))) : React__default.createElement("button", {
     onClick: () => setShowSolutions(true),
-    className: " absolute -top-3 -right-3 z-20 w-6 h-6 rounded-full flex items-center justify-center text-xs bg-emerald-500 text-white hover:shadow-lg shadow-md active:shadow-sm active:translate-y-px"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    className: "\n        absolute -top-3 -right-3 z-20\n        w-6 h-6 rounded-full flex items-center justify-center\n        text-xs bg-emerald-500 text-white hover:shadow-lg\n        shadow-md\n        active:shadow-sm active:translate-y-px"
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: faLightbulb
   })));
 }
@@ -17813,9 +17007,9 @@ function ExceptionSelector() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
 
   {
-    return /*#__PURE__*/React__default.createElement("span", {
+    return React__default.createElement("span", {
       className: "py-1 px-4 items-center flex gap-3 rounded-sm ~bg-gray-500/5"
-    }, /*#__PURE__*/React__default.createElement(RelaxedFullyQualifiedClassName, {
+    }, React__default.createElement(RelaxedFullyQualifiedClassName, {
       path: errorOccurrence.exception_class
     }));
   }
@@ -17824,13 +17018,13 @@ function ExceptionSelector() {
 function ErrorBoundaryCard({
   githubLink
 }) {
-  return /*#__PURE__*/React__default.createElement("section", {
+  return React__default.createElement("section", {
     className: "flex flex-col flex-grow px-6 sm:px-10 py-8 bg-red-600 text-red-100 shadow-lg gap-3"
-  }, /*#__PURE__*/React__default.createElement("h2", {
+  }, React__default.createElement("h2", {
     className: "text-xl font-semibold leading-snug"
-  }, "Something went wrong in Ignition!"), /*#__PURE__*/React__default.createElement("p", {
+  }, "Something went wrong in Ignition!"), React__default.createElement("p", {
     className: "text-base"
-  }, "An error occurred in Ignition's UI. Please open an issue on", ' ', /*#__PURE__*/React__default.createElement("a", {
+  }, "An error occurred in Ignition's UI. Please open an issue on", ' ', React__default.createElement("a", {
     href: githubLink,
     target: "_blank",
     className: "underline"
@@ -17884,7 +17078,7 @@ ${navigator.userAgent}
         githubLink = `https://github.com/spatie/ignition/issues/new?title=${title}&labels=bug&body=${encodeURIComponent(body)}`;
       }
 
-      return ((_this$props$fallbackC = (_this$props = this.props).fallbackComponent) == null ? void 0 : _this$props$fallbackC.call(_this$props, githubLink)) || /*#__PURE__*/React__default.createElement(ErrorBoundaryCard, {
+      return ((_this$props$fallbackC = (_this$props = this.props).fallbackComponent) == null ? void 0 : _this$props$fallbackC.call(_this$props, githubLink)) || React__default.createElement(ErrorBoundaryCard, {
         githubLink: githubLink
       });
     }
@@ -17900,42 +17094,42 @@ function ErrorCard() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const hasSolutions = errorOccurrence.solutions.length > 0;
   const isLaravelError = !!((_errorOccurrence$cont = errorOccurrence.context_items.env) != null && _errorOccurrence$cont.laravel_version);
-  return /*#__PURE__*/React__default.createElement(ErrorBoundary, null, /*#__PURE__*/React__default.createElement("section", {
-    className: "lg:flex items-stretch ~bg-white shadow-lg"
-  }, /*#__PURE__*/React__default.createElement("main", {
+  return React__default.createElement(ErrorBoundary, null, React__default.createElement("section", {
+    className: "lg:flex items-stretch bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20"
+  }, React__default.createElement("main", {
     id: "exception",
     className: "z-10 flex-grow min-w-0"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "overflow-hidden"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "px-6 sm:px-10 py-8 overflow-x-auto"
-  }, /*#__PURE__*/React__default.createElement("header", {
+  }, React__default.createElement("header", {
     className: "flex items-center justify-between gap-2"
-  }, /*#__PURE__*/React__default.createElement(ExceptionSelector, null), /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement(ExceptionSelector, null), React__default.createElement("div", {
     className: "grid grid-flow-col justify-end gap-4 text-sm ~text-gray-500"
-  }, /*#__PURE__*/React__default.createElement("span", null, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", null, React__default.createElement("span", {
     className: "tracking-wider"
-  }, "PHP"), "\xA0", errorOccurrence.language_version), errorOccurrence.framework_version && /*#__PURE__*/React__default.createElement("span", {
+  }, "PHP"), "\u00A0", errorOccurrence.language_version), errorOccurrence.framework_version && React__default.createElement("span", {
     className: "inline-flex items-center gap-1"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: isLaravelError ? faLaravel : faCodeBranch
-  }), errorOccurrence.framework_version))), /*#__PURE__*/React__default.createElement(FormattedExceptionMessage, {
+  }), errorOccurrence.framework_version))), React__default.createElement(FormattedExceptionMessage, {
     exceptionClass: errorOccurrence.exception_class,
     message: errorOccurrence.exception_message
-  })))), hasSolutions && /*#__PURE__*/React__default.createElement(Solutions, null)));
+  })))), hasSolutions && React__default.createElement(Solutions, null)));
 }
 
 function ErrorBoundarySection({
   className = '',
   githubLink
 }) {
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: `${className} flex flex-col gap-2 bg-red-50 dark:bg-red-500/10 px-6 py-4`
-  }, /*#__PURE__*/React__default.createElement("h2", {
+  }, React__default.createElement("h2", {
     className: "font-semibold leading-snug"
-  }, "Something went wrong in Ignition!"), /*#__PURE__*/React__default.createElement("p", {
+  }, "Something went wrong in Ignition!"), React__default.createElement("p", {
     className: "text-base"
-  }, "An error occurred in Ignition's UI. Please open an issue on", ' ', /*#__PURE__*/React__default.createElement("a", {
+  }, "An error occurred in Ignition's UI. Please open an issue on", ' ', React__default.createElement("a", {
     href: githubLink,
     target: "_blank",
     className: "underline"
@@ -17947,17 +17141,17 @@ function ContextGroup({
   children,
   anchor
 }) {
-  return /*#__PURE__*/React__default.createElement("section", {
+  return React__default.createElement("section", {
     className: "py-10 ~bg-white px-6 sm:px-10 min-w-0"
-  }, /*#__PURE__*/React__default.createElement("a", {
+  }, React__default.createElement("a", {
     id: `context-${anchor}`,
     className: "scroll-target"
-  }), /*#__PURE__*/React__default.createElement("h2", {
+  }), React__default.createElement("h2", {
     className: "font-bold text-xs ~text-gray-500 uppercase tracking-wider"
-  }, title), /*#__PURE__*/React__default.createElement("div", {
+  }, title), React__default.createElement("div", {
     className: "mt-3 grid grid-cols-1 gap-10"
-  }, /*#__PURE__*/React__default.createElement(ErrorBoundary, {
-    fallbackComponent: githubLink => /*#__PURE__*/React__default.createElement(ErrorBoundarySection, {
+  }, React__default.createElement(ErrorBoundary, {
+    fallbackComponent: githubLink => React__default.createElement(ErrorBoundarySection, {
       githubLink: githubLink
     })
   }, children)));
@@ -18236,17 +17430,17 @@ function ContextSection({
   anchor
 }) {
   const ref = useSectionInView(title);
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     ref: ref
-  }, /*#__PURE__*/React__default.createElement("a", {
+  }, React__default.createElement("a", {
     id: `context-${anchor}`,
     className: "scroll-target"
-  }), /*#__PURE__*/React__default.createElement("h1", {
+  }), React__default.createElement("h1", {
     className: "mb-2 flex items-center gap-2 font-semibold text-lg ~text-indigo-600"
-  }, title, /*#__PURE__*/React__default.createElement("span", {
+  }, title, React__default.createElement("span", {
     className: "opacity-50 ~text-indigo-600 text-sm"
-  }, icon)), /*#__PURE__*/React__default.createElement(ErrorBoundary, {
-    fallbackComponent: githubLink => /*#__PURE__*/React__default.createElement(ErrorBoundarySection, {
+  }, icon)), React__default.createElement(ErrorBoundary, {
+    fallbackComponent: githubLink => React__default.createElement(ErrorBoundarySection, {
       githubLink: githubLink
     })
   }, children));
@@ -18265,7 +17459,7 @@ function Tag({
     purple: '~text-violet-600 border-violet-600/50',
     gray: '~text-gray-500 border-gray-500/50'
   }[color];
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: `${className} ${tagColors} px-1.5 py-0.5 rounded-sm bg-opacity-20 border text-xs font-medium uppercase tracking-wider`
   }, children);
 }
@@ -18276,15 +17470,15 @@ function Request({
   headers
 }) {
   const curl = useMemo(() => curlCommand(request, requestData, headers), [request, requestData, headers]);
-  return /*#__PURE__*/React__default.createElement("div", null, /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", null, React__default.createElement("div", {
     className: "text-lg font-semibold flex items-center gap-2"
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     className: "~text-indigo-600"
-  }, request.url), /*#__PURE__*/React__default.createElement(Tag, {
+  }, request.url), React__default.createElement(Tag, {
     color: request.method.toUpperCase() == 'DELETE' ? 'red' : 'blue'
-  }, request.method.toUpperCase())), curl && /*#__PURE__*/React__default.createElement("div", {
+  }, request.method.toUpperCase())), curl && React__default.createElement("div", {
     className: "mt-2"
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     value: curl,
     language: "curl"
   })));
@@ -18302,7 +17496,7 @@ function DefinitionList(_ref) {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement("dl", _extends({
+  return React__default.createElement("dl", _extends({
     className: `grid grid-cols-1 gap-2 ${className}`
   }, props), children);
 }
@@ -18330,32 +17524,32 @@ function DefinitionListRow({
   if (React__default.isValidElement(value)) {
     valueOutput = value;
   } else if (typeof value === 'boolean') {
-    valueOutput = /*#__PURE__*/React__default.createElement("span", {
-      className: `${value ? 'text-emerald-500 bg-emerald-500/5' : 'text-red-500 bg-red-500/5'} text-sm px-3 py-2 inline-flex gap-2 items-center justify-center`
-    }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    valueOutput = React__default.createElement("span", {
+      className: `${value ? 'text-emerald-500 bg-emerald-500/5' : 'text-red-500 bg-red-800/5'} text-sm px-3 py-2 inline-flex gap-2 items-center justify-center`
+    }, React__default.createElement(FontAwesomeIcon, {
       className: `${value} ? 'text-emerald-500' : 'text-red-500`,
       icon: value ? faCheck : faTimes
-    }), /*#__PURE__*/React__default.createElement("span", {
+    }), React__default.createElement("span", {
       className: "font-mono"
     }, value ? 'true' : 'false'));
   } else if (typeof value === 'object') {
-    valueOutput = /*#__PURE__*/React__default.createElement(CodeSnippet, {
+    valueOutput = React__default.createElement(CodeSnippet, {
       value: jsonStringify(value),
       language: "json"
     });
   } else if (typeof value === 'string') {
-    valueOutput = /*#__PURE__*/React__default.createElement(CodeSnippet, {
+    valueOutput = React__default.createElement(CodeSnippet, {
       value: value
     });
   } else if (typeof value === 'number') {
-    valueOutput = /*#__PURE__*/React__default.createElement(CodeSnippet, {
+    valueOutput = React__default.createElement(CodeSnippet, {
       value: String(value)
     });
   }
 
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: `${stacked ? 'flex flex-col' : 'flex items-baseline gap-10'}  ${className}`
-  }, /*#__PURE__*/React__default.createElement("dt", {
+  }, React__default.createElement("dt", {
     className: `
                 ${stacked ? 'self-start pt-2 pb-1.5 leading-tight' : expandLabel ? 'flex-grow truncate min-w-[8rem] max-w-max' : 'flex-none truncate w-32'}
             `,
@@ -18365,7 +17559,7 @@ function DefinitionListRow({
     onMouseOut: () => {
       stopExpandLabel();
     }
-  }, label), /*#__PURE__*/React__default.createElement("dd", {
+  }, label), React__default.createElement("dd", {
     className: "flex-grow min-w-0"
   }, valueOutput));
 }
@@ -18373,7 +17567,7 @@ function DefinitionListRow({
 function ContextList({
   items
 }) {
-  return /*#__PURE__*/React__default.createElement(DefinitionList, null, Object.entries(items || {}).map(([key, value]) => /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  return React__default.createElement(DefinitionList, null, Object.entries(items || {}).map(([key, value]) => React__default.createElement(DefinitionList.Row, {
     key: key,
     label: key,
     value: value
@@ -18831,7 +18025,7 @@ function Headers({
 }) {
   let filteredHeaders = omitBy_1(headers, isNil_1);
   filteredHeaders = omitBy_1(filteredHeaders, isEmpty_1);
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: filteredHeaders
   });
 }
@@ -18839,7 +18033,7 @@ function Headers({
 function QueryString({
   requestData
 }) {
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: requestData.queryString || {}
   });
 }
@@ -18854,7 +18048,7 @@ function Body() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  return React__default.createElement(CodeSnippet, {
     value: jsonStringify(body)
   });
 }
@@ -18869,9 +18063,9 @@ function Files() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: "col-span-2"
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     value: jsonStringify(files)
   }));
 }
@@ -18879,7 +18073,7 @@ function Files() {
 function Session({
   session
 }) {
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: session
   });
 }
@@ -18887,7 +18081,7 @@ function Session({
 function Cookies({
   cookies
 }) {
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: cookies
   });
 }
@@ -18900,7 +18094,7 @@ function LivewireData() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: livewire.data
   });
 }
@@ -18913,7 +18107,7 @@ function LivewireComponent() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement(ContextList, {
+  return React__default.createElement(ContextList, {
     items: {
       Component: livewire.component_class,
       Alias: livewire.component_alias,
@@ -18930,10 +18124,10 @@ function LivewireUpdates() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement(DefinitionList, null, livewire.updates.map(({
+  return React__default.createElement(DefinitionList, null, livewire.updates.map(({
     payload,
     type
-  }, index) => /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }, index) => React__default.createElement(DefinitionList.Row, {
     key: index,
     label: type,
     value: payload
@@ -18948,7 +18142,7 @@ function UnorderedList(_ref) {
   } = _ref,
       props = _objectWithoutPropertiesLoose(_ref, _excluded$1);
 
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, children && /*#__PURE__*/React__default.createElement("ul", _extends({
+  return React__default.createElement(React__default.Fragment, null, children && React__default.createElement("ul", _extends({
     className: `gap-y-2 flex flex-col ${className}`
   }, props), children));
 }
@@ -18962,17 +18156,17 @@ function UnorderedListItem({
   if (React__default.isValidElement(value)) {
     valueOutput = value;
   } else if (typeof value === 'object') {
-    valueOutput = /*#__PURE__*/React__default.createElement(CodeSnippet, {
+    valueOutput = React__default.createElement(CodeSnippet, {
       value: jsonStringify(value),
       language: "json"
     });
   } else if (typeof value === 'string') {
-    valueOutput = /*#__PURE__*/React__default.createElement(CodeSnippet, {
+    valueOutput = React__default.createElement(CodeSnippet, {
       value: value
     });
   }
 
-  return /*#__PURE__*/React__default.createElement("li", null, valueOutput);
+  return React__default.createElement("li", null, valueOutput);
 }
 
 function Routing({
@@ -18980,22 +18174,22 @@ function Routing({
 }) {
   var _route$routeParameter;
 
-  return /*#__PURE__*/React__default.createElement(DefinitionList, null, /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  return React__default.createElement(DefinitionList, null, React__default.createElement(DefinitionList.Row, {
     value: route.controllerAction,
     label: "Controller"
-  }), route.route && /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }), route.route && React__default.createElement(DefinitionList.Row, {
     value: route.route,
     label: "Route name"
-  }), !!((_route$routeParameter = route.routeParameters) != null && _route$routeParameter.length) && /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
-    value: /*#__PURE__*/React__default.createElement(DefinitionList, null, Object.entries(route.routeParameters).map(([key, parameter]) => /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }), !!((_route$routeParameter = route.routeParameters) != null && _route$routeParameter.length) && React__default.createElement(DefinitionList.Row, {
+    value: React__default.createElement(DefinitionList, null, Object.entries(route.routeParameters).map(([key, parameter]) => React__default.createElement(DefinitionList.Row, {
       stacked: true,
       key: key,
       label: key,
       value: parameter
     }))),
     label: "Route parameters"
-  }), route.middleware && /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
-    value: /*#__PURE__*/React__default.createElement(UnorderedList, null, (route.middleware || []).map((middleware, i) => /*#__PURE__*/React__default.createElement(UnorderedList.Item, {
+  }), route.middleware && React__default.createElement(DefinitionList.Row, {
+    value: React__default.createElement(UnorderedList, null, (route.middleware || []).map((middleware, i) => React__default.createElement(UnorderedList.Item, {
       key: i,
       value: middleware
     }))),
@@ -19020,7 +18214,7 @@ function SfDump(_ref) {
 
     window.Sfdump(match[0]);
   }, [value]);
-  return /*#__PURE__*/React__default.createElement("div", _extends({
+  return React__default.createElement("div", _extends({
     className: "~bg-gray-500/5 px-4 py-2",
     dangerouslySetInnerHTML: {
       __html: value
@@ -19036,17 +18230,17 @@ function View() {
     return null;
   }
 
-  return /*#__PURE__*/React__default.createElement(DefinitionList, null, /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
-    value: /*#__PURE__*/React__default.createElement(EditorLink, {
+  return React__default.createElement(DefinitionList, null, React__default.createElement(DefinitionList.Row, {
+    value: React__default.createElement(EditorLink, {
       path: view.view
     }),
     label: "View"
-  }), view.data && /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
-    value: /*#__PURE__*/React__default.createElement(DefinitionList, null, Object.entries(view.data).map(([key, data]) => /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }), view.data && React__default.createElement(DefinitionList.Row, {
+    value: React__default.createElement(DefinitionList, null, Object.entries(view.data).map(([key, data]) => React__default.createElement(DefinitionList.Row, {
       stacked: true,
       key: key,
       label: key,
-      value: /*#__PURE__*/React__default.createElement(SfDump, {
+      value: React__default.createElement(SfDump, {
         value: data
       })
     }))),
@@ -19336,19 +18530,19 @@ var md5 = createCommonjsModule(function (module) {
 function User({
   user
 }) {
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, user.email && /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement(React__default.Fragment, null, user.email && React__default.createElement("div", {
     className: "mb-2 flex items-center gap-3"
-  }, /*#__PURE__*/React__default.createElement("div", null, /*#__PURE__*/React__default.createElement("img", {
+  }, React__default.createElement("div", null, React__default.createElement("img", {
     className: "inline-block h-9 w-9 rounded-full",
     alt: user.email,
     src: `https://gravatar.com/avatar/${md5(user.email)}/?s=240`
-  })), /*#__PURE__*/React__default.createElement("div", {
+  })), React__default.createElement("div", {
     className: "leading-tight"
-  }, user.name && /*#__PURE__*/React__default.createElement("p", {
+  }, user.name && React__default.createElement("p", {
     className: "font-semibold"
-  }, user.name), /*#__PURE__*/React__default.createElement("p", {
+  }, user.name), React__default.createElement("p", {
     className: "text-sm"
-  }, user.email))), /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, user.email))), React__default.createElement(CodeSnippet, {
     value: jsonStringify(user),
     language: "json"
   }));
@@ -19358,17 +18552,17 @@ function Alert({
   children,
   className = ''
 }) {
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: `${className}`
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex items-center gap-2 bg-yellow-50 dark:bg-yellow-500/10 px-4 py-2"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex-shrink-0",
     "aria-hidden": "true"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     className: "text-yellow-500 ",
     icon: faExclamationTriangle
-  })), /*#__PURE__*/React__default.createElement("p", {
+  })), React__default.createElement("p", {
     className: "text-sm"
   }, children)));
 }
@@ -20423,26 +19617,26 @@ function Git({
   const {
     commitUrl
   } = getGitInfo(git.remote, git.hash);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, git.hash && git.message && /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement(React__default.Fragment, null, git.hash && git.message && React__default.createElement("div", {
     className: "flex items-center gap-4"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex-grow font-semibold"
-  }, git.message), /*#__PURE__*/React__default.createElement("div", {
+  }, git.message), React__default.createElement("div", {
     className: "~bg-gray-500/5 flex items-center"
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     transparent: true,
     overflowX: false,
     value: git.hash
-  }), commitUrl && /*#__PURE__*/React__default.createElement("a", {
+  }), commitUrl && React__default.createElement("a", {
     href: commitUrl,
     target: "_blank",
     className: "mr-4"
-  }, /*#__PURE__*/React__default.createElement(SmallButton, null, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(SmallButton, null, React__default.createElement(FontAwesomeIcon, {
     className: "group-hover:text-indigo-500",
     icon: faExternalLinkAlt
-  }), "View commit ", git.hash.substr(0, 7))))), git.isDirty && /*#__PURE__*/React__default.createElement("div", null, /*#__PURE__*/React__default.createElement(Alert, {
+  }), "View commit ", git.hash.substr(0, 7))))), git.isDirty && React__default.createElement("div", null, React__default.createElement(Alert, {
     className: "mt-4"
-  }, "Last commit is dirty. (Un)staged changes have been made since this commit.")), git.tag && /*#__PURE__*/React__default.createElement(DefinitionList, null, /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }, "Last commit is dirty. (Un)staged changes have been made since this commit.")), git.tag && React__default.createElement(DefinitionList, null, React__default.createElement(DefinitionList.Row, {
     label: "Latest tag",
     value: git.tag
   })));
@@ -21113,11 +20307,11 @@ function Versions({
   env
 }) {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
-  return /*#__PURE__*/React__default.createElement(DefinitionList, null, errorOccurrence.application_version && /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  return React__default.createElement(DefinitionList, null, errorOccurrence.application_version && React__default.createElement(DefinitionList.Row, {
     key: "app_version",
     value: errorOccurrence.application_version,
     label: "App Version"
-  }), Object.entries(env).map(([key, value]) => /*#__PURE__*/React__default.createElement(DefinitionList.Row, {
+  }), Object.entries(env).map(([key, value]) => React__default.createElement(DefinitionList.Row, {
     key: key,
     value: value,
     label: startCase_1(key)
@@ -21127,7 +20321,7 @@ function Versions({
 function ContextNav({
   children
 }) {
-  return /*#__PURE__*/React__default.createElement("ul", {
+  return React__default.createElement("ul", {
     className: "grid grid-cols-1 gap-10"
   }, children);
 }
@@ -21137,10 +20331,10 @@ function ContextNavGroup({
   children,
   anchor
 }) {
-  return /*#__PURE__*/React__default.createElement("li", null, /*#__PURE__*/React__default.createElement("a", {
+  return React__default.createElement("li", null, React__default.createElement("a", {
     href: `#context-${anchor}`,
     className: "uppercase tracking-wider ~text-gray-500 text-xs font-bold"
-  }, title), /*#__PURE__*/React__default.createElement("ul", {
+  }, title), React__default.createElement("ul", {
     className: "mt-3 grid grid-cols-1 gap-3"
   }, children));
 }
@@ -21151,16 +20345,16 @@ function ContextNavItem({
   anchor,
   active = false
 }) {
-  return /*#__PURE__*/React__default.createElement("li", null, /*#__PURE__*/React__default.createElement("a", {
+  return React__default.createElement("li", null, React__default.createElement("a", {
     href: `#context-${anchor}`,
     className: `
                 flex items-center gap-3
                 group text-base hover:text-indigo-500
                 ${active ? '~text-indigo-600' : ''}
             `
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     className: "opacity-50"
-  }, icon), /*#__PURE__*/React__default.createElement("span", null, title)));
+  }, icon), React__default.createElement("span", null, title)));
 }
 
 function ContextSections({
@@ -21169,20 +20363,20 @@ function ContextSections({
   const {
     inView
   } = useContext(InViewContext);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement("nav", {
+  return React__default.createElement(React__default.Fragment, null, React__default.createElement("nav", {
     className: "hidden sm:block min-w-[8rem] flex-none mr-10 lg:mr-20"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "sticky top-[7.5rem]"
-  }, /*#__PURE__*/React__default.createElement(ContextNav, null, Children.map(children, group => /*#__PURE__*/React__default.createElement(React__default.Fragment, null, group && /*#__PURE__*/React__default.createElement(ContextNavGroup, {
+  }, React__default.createElement(ContextNav, null, Children.map(children, group => React__default.createElement(React__default.Fragment, null, group && React__default.createElement(ContextNavGroup, {
     title: group.props.title,
     anchor: group.props.anchor
-  }, Children.map(group.props.children, section => /*#__PURE__*/React__default.createElement(React__default.Fragment, null, section && section.type === ContextSection && /*#__PURE__*/React__default.createElement(ContextNavItem, {
+  }, Children.map(group.props.children, section => React__default.createElement(React__default.Fragment, null, section && section.type === ContextSection && React__default.createElement(ContextNavItem, {
     icon: section.props.icon,
     active: inView[inView.length - 1] === section.props.title,
     title: section.props.title,
     anchor: section.props.anchor
-  }))))))))), /*#__PURE__*/React__default.createElement("div", {
-    className: "overflow-hidden grid grid-cols-1 gap-px shadow-lg flex-grow"
+  }))))))))), React__default.createElement("div", {
+    className: "overflow-hidden grid grid-cols-1 gap-px bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 flex-grow"
   }, children));
 }
 
@@ -21190,7 +20384,7 @@ function InViewContextProvider({
   children
 }) {
   const [inView, setInView] = useState([]);
-  return /*#__PURE__*/React__default.createElement(InViewContext.Provider, {
+  return React__default.createElement(InViewContext.Provider, {
     value: {
       inView,
       setInView
@@ -21201,7 +20395,7 @@ function InViewContextProvider({
 function LiveWireIcon({
   className = ''
 }) {
-  return /*#__PURE__*/React__default.createElement("svg", {
+  return React__default.createElement("svg", {
     version: "1.1",
     xmlns: "http://www.w3.org/2000/svg",
     x: "0px",
@@ -21209,28 +20403,28 @@ function LiveWireIcon({
     viewBox: "0 0 512 512",
     enableBackground: "new 0 0 512 512",
     className: `${className}`
-  }, /*#__PURE__*/React__default.createElement("path", {
+  }, React__default.createElement("path", {
     fill: "currentcolor",
-    d: "M381.6,334.8c-24.7,0-27.7,33.6-45.2,44.6v52c0,17.6,14.2,31.8,31.8,31.8c17.6,0,31.8-14.2,31.8-31.8v-88.6 C395,338.1,389.2,334.8,381.6,334.8z"
-  }), /*#__PURE__*/React__default.createElement("path", {
+    d: "M381.6,334.8c-24.7,0-27.7,33.6-45.2,44.6v52c0,17.6,14.2,31.8,31.8,31.8c17.6,0,31.8-14.2,31.8-31.8v-88.6\n        C395,338.1,389.2,334.8,381.6,334.8z"
+  }), React__default.createElement("path", {
     fill: "currentcolor",
-    d: "M263.2,334.8c-25.5,0-27.8,35.8-46.9,45.7v96.2c0,19.5,15.8,35.3,35.3,35.3s35.3-15.8,35.3-35.3V349.1 C280.9,341.1,273.9,334.8,263.2,334.8z"
-  }), /*#__PURE__*/React__default.createElement("path", {
+    d: "M263.2,334.8c-25.5,0-27.8,35.8-46.9,45.7v96.2c0,19.5,15.8,35.3,35.3,35.3s35.3-15.8,35.3-35.3V349.1\n        C280.9,341.1,273.9,334.8,263.2,334.8z"
+  }), React__default.createElement("path", {
     fill: "currentcolor",
-    d: "M144.8,334.8c-22.9,0-27.1,28.9-41.6,41.9l0,38c0,17.6,14.2,31.8,31.8,31.8c17.6,0,31.8-14.2,31.8-31.8v-67.9 C161.2,339.9,154.5,334.8,144.8,334.8z"
-  }), /*#__PURE__*/React__default.createElement("path", {
+    d: "M144.8,334.8c-22.9,0-27.1,28.9-41.6,41.9l0,38c0,17.6,14.2,31.8,31.8,31.8c17.6,0,31.8-14.2,31.8-31.8v-67.9\n        C161.2,339.9,154.5,334.8,144.8,334.8z"
+  }), React__default.createElement("path", {
     id: "Body-Copy-4",
     fill: "currentcolor",
     fillRule: "evenodd",
     clipRule: "evenodd",
-    d: "M458.9,340.2c-8.3,12.6-14.7,28.2-31.7,28.2 c-28.6,0-30.1-44-58.7-44c-28.6,0-27,44-55.6,44c-28.6,0-30.1-44-58.7-44s-27,44-55.6,44s-30.1-44-58.7-44s-27,44-55.6,44 c-9,0-15.3-4.4-20.6-10.3c-20.4-35.6-32.2-77.2-32.2-121.8C31.6,105.8,132.4,0,256.7,0s225.1,105.8,225.1,236.2 C481.8,273.5,473.6,308.8,458.9,340.2z"
-  }), /*#__PURE__*/React__default.createElement("path", {
+    d: "M458.9,340.2c-8.3,12.6-14.7,28.2-31.7,28.2\n\t\tc-28.6,0-30.1-44-58.7-44c-28.6,0-27,44-55.6,44c-28.6,0-30.1-44-58.7-44s-27,44-55.6,44s-30.1-44-58.7-44s-27,44-55.6,44\n\t\tc-9,0-15.3-4.4-20.6-10.3c-20.4-35.6-32.2-77.2-32.2-121.8C31.6,105.8,132.4,0,256.7,0s225.1,105.8,225.1,236.2\n\t\tC481.8,273.5,473.6,308.8,458.9,340.2z"
+  }), React__default.createElement("path", {
     id: "Oval",
     fillRule: "evenodd",
     clipRule: "evenodd",
     fill: "#FFFFFF",
-    d: "M244.6,295.1c78.3,0,111.2-45.4,111.2-109.9 S306.1,61.4,244.6,61.4s-111.2,59.4-111.2,123.9S166.4,295.1,244.6,295.1z"
-  }), /*#__PURE__*/React__default.createElement("ellipse", {
+    d: "M244.6,295.1c78.3,0,111.2-45.4,111.2-109.9\n\t\tS306.1,61.4,244.6,61.4s-111.2,59.4-111.2,123.9S166.4,295.1,244.6,295.1z"
+  }), React__default.createElement("ellipse", {
     id: "Oval_1_",
     fill: "currentcolor",
     fillRule: "evenodd",
@@ -21239,7 +20433,7 @@ function LiveWireIcon({
     cy: "142.9",
     rx: "41.7",
     ry: "46"
-  }), /*#__PURE__*/React__default.createElement("ellipse", {
+  }), React__default.createElement("ellipse", {
     id: "Oval_2_",
     fillRule: "evenodd",
     clipRule: "evenodd",
@@ -21257,149 +20451,149 @@ function Context() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const context = errorOccurrence.context_items;
   const requestData = context.request_data;
-  return /*#__PURE__*/React__default.createElement(ErrorBoundary, null, /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement(ErrorBoundary, null, React__default.createElement("div", {
     className: "flex items-stretch"
-  }, /*#__PURE__*/React__default.createElement(InViewContextProvider, null, /*#__PURE__*/React__default.createElement(ContextSections, null, context.request_data && context.request && context.headers && /*#__PURE__*/React__default.createElement(ContextGroup, {
+  }, React__default.createElement(InViewContextProvider, null, React__default.createElement(ContextSections, null, context.request_data && context.request && context.headers && React__default.createElement(ContextGroup, {
     title: "Request",
     anchor: "request"
-  }, /*#__PURE__*/React__default.createElement(Request, {
+  }, React__default.createElement(Request, {
     request: context.request,
     requestData: context.request_data,
     headers: context.headers
-  }), /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), React__default.createElement(ContextSection, {
     title: "Headers",
     anchor: "request-headers",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faExchangeAlt
     }),
-    children: /*#__PURE__*/React__default.createElement(Headers, {
+    children: React__default.createElement(Headers, {
       headers: context.headers
     })
-  }), !!Object.values(context.request_data.queryString || []).length && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), !!Object.values(context.request_data.queryString || []).length && React__default.createElement(ContextSection, {
     title: "Query String",
     anchor: "request-query-string",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faQuestionCircle
     }),
-    children: /*#__PURE__*/React__default.createElement(QueryString, {
+    children: React__default.createElement(QueryString, {
       requestData: context.request_data
     })
-  }), /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), React__default.createElement(ContextSection, {
     title: "Body",
     anchor: "request-body",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faCode
     }),
-    children: /*#__PURE__*/React__default.createElement(Body, null)
-  }), !!(requestData != null && (_requestData$files = requestData.files) != null && _requestData$files.length) && /*#__PURE__*/React__default.createElement(ContextSection, {
+    children: React__default.createElement(Body, null)
+  }), !!(requestData != null && (_requestData$files = requestData.files) != null && _requestData$files.length) && React__default.createElement(ContextSection, {
     title: "Files",
     anchor: "request-files",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faFile
     }),
-    children: /*#__PURE__*/React__default.createElement(Files, null)
-  }), !!((_context$session = context.session) != null && _context$session.length) && /*#__PURE__*/React__default.createElement(ContextSection, {
+    children: React__default.createElement(Files, null)
+  }), !!((_context$session = context.session) != null && _context$session.length) && React__default.createElement(ContextSection, {
     title: "Session",
     anchor: "request-session",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faHourglassHalf
     }),
-    children: /*#__PURE__*/React__default.createElement(Session, {
+    children: React__default.createElement(Session, {
       session: context.session
     })
-  }), !!((_context$cookies = context.cookies) != null && _context$cookies.length) && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), !!((_context$cookies = context.cookies) != null && _context$cookies.length) && React__default.createElement(ContextSection, {
     title: "Cookies",
     anchor: "request-cookies",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faCookieBite
     }),
-    children: /*#__PURE__*/React__default.createElement(Cookies, {
+    children: React__default.createElement(Cookies, {
       cookies: context.cookies
     })
-  })), /*#__PURE__*/React__default.createElement(ContextGroup, {
+  })), React__default.createElement(ContextGroup, {
     title: "App",
     anchor: "app"
-  }, context.route && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }, context.route && React__default.createElement(ContextSection, {
     title: "Routing",
     anchor: "app-routing",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faRandom
     }),
-    children: /*#__PURE__*/React__default.createElement(Routing, {
+    children: React__default.createElement(Routing, {
       route: context.route
     })
-  }), context.view && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), context.view && React__default.createElement(ContextSection, {
     title: "Views",
     anchor: "app-views",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faPaintRoller
     }),
-    children: /*#__PURE__*/React__default.createElement(View, null)
-  })), context.livewire && /*#__PURE__*/React__default.createElement(ContextGroup, {
+    children: React__default.createElement(View, null)
+  })), context.livewire && React__default.createElement(ContextGroup, {
     title: "Livewire",
     anchor: "livewire"
-  }, /*#__PURE__*/React__default.createElement(ContextSection, {
+  }, React__default.createElement(ContextSection, {
     title: "Component",
     anchor: "livewire-component",
-    icon: /*#__PURE__*/React__default.createElement(LiveWireIcon, {
+    icon: React__default.createElement(LiveWireIcon, {
       className: "svg-inline--fa fa-w-16 fa-fw"
     }),
-    children: /*#__PURE__*/React__default.createElement(LivewireComponent, null)
-  }), /*#__PURE__*/React__default.createElement(ContextSection, {
+    children: React__default.createElement(LivewireComponent, null)
+  }), React__default.createElement(ContextSection, {
     title: "Updates",
     anchor: "livewire-updates",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faSatelliteDish
     }),
-    children: /*#__PURE__*/React__default.createElement(LivewireUpdates, null)
-  }), /*#__PURE__*/React__default.createElement(ContextSection, {
+    children: React__default.createElement(LivewireUpdates, null)
+  }), React__default.createElement(ContextSection, {
     title: "Data",
     anchor: "livewire-data",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faTh
     }),
-    children: /*#__PURE__*/React__default.createElement(LivewireData, null)
-  })), /*#__PURE__*/React__default.createElement(ContextGroup, {
+    children: React__default.createElement(LivewireData, null)
+  })), React__default.createElement(ContextGroup, {
     title: "Context",
     anchor: "context"
-  }, context.user && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }, context.user && React__default.createElement(ContextSection, {
     title: "User",
     anchor: "user-user",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faUser
     }),
-    children: /*#__PURE__*/React__default.createElement(User, {
+    children: React__default.createElement(User, {
       user: context.user
     })
-  }), context.git && /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), context.git && React__default.createElement(ContextSection, {
     title: "Git",
     anchor: "context-git",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faCodeBranch
     }),
-    children: /*#__PURE__*/React__default.createElement(Git, {
+    children: React__default.createElement(Git, {
       git: context.git
     })
-  }), /*#__PURE__*/React__default.createElement(ContextSection, {
+  }), React__default.createElement(ContextSection, {
     title: "Versions",
     anchor: "context-versions",
-    icon: /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+    icon: React__default.createElement(FontAwesomeIcon, {
       fixedWidth: true,
       icon: faSlidersH
     }),
-    children: /*#__PURE__*/React__default.createElement(Versions, {
+    children: React__default.createElement(Versions, {
       env: context.env || {}
     })
   }))))));
@@ -21420,13 +20614,13 @@ function DebugTabs({
     };
   }).filter(tab => tab.count);
   const Tab = tabs[currentTabIndex].component;
-  return /*#__PURE__*/React__default.createElement("div", {
-    className: "bg-gray-300/50 dark:bg-black/10 shadow-inner"
-  }, /*#__PURE__*/React__default.createElement("nav", {
+  return React__default.createElement("div", {
+    className: "bg-gray-300/50 dark:bg-black/10 shadow-inner rounded-lg"
+  }, React__default.createElement("nav", {
     className: "z-10 flex justify-center items-center"
-  }, /*#__PURE__*/React__default.createElement("ul", {
+  }, React__default.createElement("ul", {
     className: "-my-5 flex justify-start items-center rounded-full shadow-lg bg-indigo-500 text-white space-x-px"
-  }, tabs.map((tab, i) => /*#__PURE__*/React__default.createElement("li", {
+  }, tabs.map((tab, i) => React__default.createElement("li", {
     key: i,
     className: `
                                     ${i === currentTabIndex ? 'bg-indigo-600' : 'bg-indigo-500 text-indigo-100'}
@@ -21434,19 +20628,19 @@ function DebugTabs({
                                     ${i === tabs.length - 1 ? 'rounded-r-full' : ''}
                                     hover:text-white
                                 `
-  }, /*#__PURE__*/React__default.createElement("button", {
+  }, React__default.createElement("button", {
     onClick: () => setCurrentTabIndex(i),
     className: "group flex items-center px-3 sm:px-5 h-10 uppercase tracking-wider text-xs font-medium "
-  }, /*#__PURE__*/React__default.createElement("span", {
+  }, React__default.createElement("span", {
     className: "mr-1.5 inline-flex items-center justify-center px-1 min-w-[1rem] h-4 bg-gray-900/30 text-white rounded-full text-xs"
-  }, tab.count), /*#__PURE__*/React__default.createElement("span", null, tab.name)))))), /*#__PURE__*/React__default.createElement(ErrorBoundary, {
-    fallbackComponent: githubLink => /*#__PURE__*/React__default.createElement(ErrorBoundarySection, {
+  }, tab.count), React__default.createElement("span", null, tab.name)))))), React__default.createElement(ErrorBoundary, {
+    fallbackComponent: githubLink => React__default.createElement(ErrorBoundarySection, {
       githubLink: githubLink,
       className: "pt-10"
     })
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "grid grid-cols-1 gap-10 py-10 px-6 sm:px-10"
-  }, /*#__PURE__*/React__default.createElement(Tab, null))));
+  }, React__default.createElement(Tab, null))));
 }
 
 DebugTabs.Tab = _props => null;
@@ -21472,42 +20666,42 @@ function DebugItem({
     alert: 'red',
     emergency: 'red'
   };
-  return /*#__PURE__*/React__default.createElement("div", {
+  return React__default.createElement("div", {
     className: "min-w-0 grid grid-cols-1 gap-2"
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "flex items-center gap-1"
-  }, /*#__PURE__*/React__default.createElement(Tag, {
+  }, React__default.createElement(Tag, {
     color: level ? logLevelColors[level] : 'gray',
     className: "font-mono"
-  }, time.toLocaleTimeString()), level && /*#__PURE__*/React__default.createElement(Tag, {
+  }, time.toLocaleTimeString()), level && React__default.createElement(Tag, {
     color: logLevelColors[level]
-  }, level), meta && Object.entries(meta).map(([key, value]) => /*#__PURE__*/React__default.createElement(React__default.Fragment, {
+  }, level), meta && Object.entries(meta).map(([key, value]) => React__default.createElement(React__default.Fragment, {
     key: key
-  }, key === 'runtime' && /*#__PURE__*/React__default.createElement(Tag, {
+  }, key === 'runtime' && React__default.createElement(Tag, {
     className: "inline-flex items-center gap-2"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     title: "Runtime",
     className: "opacity-50",
     icon: faStopwatch
-  }), ' ', value), key === 'connection' && /*#__PURE__*/React__default.createElement(Tag, {
+  }), ' ', value), key === 'connection' && React__default.createElement(Tag, {
     className: "inline-flex items-center gap-2"
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     title: "Connection",
     className: "opacity-50",
     icon: faDatabase
-  }), ' ', value), key !== 'runtime' && key !== 'connection' && /*#__PURE__*/React__default.createElement(Tag, null, key, ": ", value))), context && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, /*#__PURE__*/React__default.createElement("div", {
+  }), ' ', value), key !== 'runtime' && key !== 'connection' && React__default.createElement(Tag, null, key, ": ", value))), context && React__default.createElement(React__default.Fragment, null, React__default.createElement("div", {
     className: "ml-auto"
-  }, /*#__PURE__*/React__default.createElement(SmallButton, {
+  }, React__default.createElement(SmallButton, {
     onClick: () => setShowRawContext(!showRawContext)
-  }, /*#__PURE__*/React__default.createElement(FontAwesomeIcon, {
+  }, React__default.createElement(FontAwesomeIcon, {
     icon: showRawContext ? faListUl : faCode,
     className: "text-[8px] ~text-gray-500 group-hover:text-indigo-500"
-  }), showRawContext ? 'As list' : 'Raw')))), /*#__PURE__*/React__default.createElement("div", null, children), context && /*#__PURE__*/React__default.createElement(React__default.Fragment, null, showRawContext ? /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }), showRawContext ? 'As list' : 'Raw')))), React__default.createElement("div", null, children), context && React__default.createElement(React__default.Fragment, null, showRawContext ? React__default.createElement(CodeSnippet, {
     value: jsonStringify(context),
     language: "json"
-  }) : /*#__PURE__*/React__default.createElement("div", {
+  }) : React__default.createElement("div", {
     className: "pl-4"
-  }, /*#__PURE__*/React__default.createElement(ContextList, {
+  }, React__default.createElement(ContextList, {
     items: context
   }))));
 }
@@ -21515,12 +20709,12 @@ function DebugItem({
 function Logs() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const logs = Object.values(errorOccurrence.context_items.logs);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, logs.map((log, index) => /*#__PURE__*/React__default.createElement(DebugItem, {
+  return React__default.createElement(React__default.Fragment, null, logs.map((log, index) => React__default.createElement(DebugItem, {
     key: index,
     context: log.context,
     level: log.level,
     time: unixToDate(log.microtime)
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     value: log.message
   }))));
 }
@@ -21528,16 +20722,16 @@ function Logs() {
 function Dumps() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const dumps = Object.values(errorOccurrence.context_items.dumps);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, dumps.map((dump, index) => /*#__PURE__*/React__default.createElement(DebugItem, {
+  return React__default.createElement(React__default.Fragment, null, dumps.map((dump, index) => React__default.createElement(DebugItem, {
     key: index,
     time: unixToDate(dump.microtime)
-  }, /*#__PURE__*/React__default.createElement("div", {
+  }, React__default.createElement("div", {
     className: "mb-2"
-  }, /*#__PURE__*/React__default.createElement(EditorLink, {
+  }, React__default.createElement(EditorLink, {
     path: dump.file,
     lineNumber: dump.line_number,
     className: "text-sm"
-  })), /*#__PURE__*/React__default.createElement(SfDump, {
+  })), React__default.createElement(SfDump, {
     value: dump.html_dump
   }))));
 }
@@ -21545,14 +20739,14 @@ function Dumps() {
 function Queries() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const queries = Object.values(errorOccurrence.context_items.queries);
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, queries.map((query, index) => /*#__PURE__*/React__default.createElement(DebugItem, {
+  return React__default.createElement(React__default.Fragment, null, queries.map((query, index) => React__default.createElement(DebugItem, {
     key: index,
     time: unixToDate(query.microtime),
     meta: {
       runtime: `${query.time}ms`,
       connection: query.connection_name
     }
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     value: query.sql,
     language: "sql"
   }))));
@@ -21561,12 +20755,12 @@ function Queries() {
 function Glows() {
   const errorOccurrence = useContext(ErrorOccurrenceContext);
   const glows = errorOccurrence.glows;
-  return /*#__PURE__*/React__default.createElement(React__default.Fragment, null, glows.map((glow, index) => /*#__PURE__*/React__default.createElement(DebugItem, {
+  return React__default.createElement(React__default.Fragment, null, glows.map((glow, index) => React__default.createElement(DebugItem, {
     key: index,
     level: glow.message_level,
     context: glow.meta_data,
     time: unixToDate(glow.microtime)
-  }, /*#__PURE__*/React__default.createElement(CodeSnippet, {
+  }, React__default.createElement(CodeSnippet, {
     value: glow.name
   }))));
 }
@@ -21577,19 +20771,19 @@ function Debug() {
   const queries = errorOccurrence.context_items.queries;
   const logs = errorOccurrence.context_items.logs;
   const glows = errorOccurrence.glows;
-  return /*#__PURE__*/React__default.createElement(ErrorBoundary, null, /*#__PURE__*/React__default.createElement(DebugTabs, null, /*#__PURE__*/React__default.createElement(DebugTabs.Tab, {
+  return React__default.createElement(ErrorBoundary, null, React__default.createElement(DebugTabs, null, React__default.createElement(DebugTabs.Tab, {
     component: Dumps,
     name: "Dumps",
     count: Object.keys(dumps || []).length
-  }), /*#__PURE__*/React__default.createElement(DebugTabs.Tab, {
+  }), React__default.createElement(DebugTabs.Tab, {
     component: Glows,
     name: "Glows",
     count: glows.length
-  }), /*#__PURE__*/React__default.createElement(DebugTabs.Tab, {
+  }), React__default.createElement(DebugTabs.Tab, {
     component: Queries,
     name: "Queries",
     count: Object.keys(queries || []).length
-  }), /*#__PURE__*/React__default.createElement(DebugTabs.Tab, {
+  }), React__default.createElement(DebugTabs.Tab, {
     component: Logs,
     name: "Logs",
     count: Object.keys(logs || []).length
@@ -21600,31 +20794,31 @@ function InlineCodeSnippet({
   children,
   className = ''
 }) {
-  return /*#__PURE__*/React__default.createElement("code", {
+  return React__default.createElement("code", {
     className: `font-mono leading-relaxed font-normal ~bg-gray-500/5 px-1 py-1 ${className}`
   }, children);
 }
 
 function FlareIcon() {
-  return /*#__PURE__*/React__default.createElement("svg", {
+  return React__default.createElement("svg", {
     viewBox: "0 0 682 1024",
     className: "w-4 h-5 ml-1.5"
-  }, /*#__PURE__*/React__default.createElement("polygon", {
+  }, React__default.createElement("polygon", {
     points: "235.3,510.5 21.5,387 21.5,140.2 236.5,264.1 ",
     style: {
       fill: 'rgb(81, 219, 158)'
     }
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     points: "235.3,1004.8 21.5,881.4 21.5,634.5 234.8,757.9 ",
     style: {
       fill: 'rgb(121, 0, 245)'
     }
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     points: "448.9,386.9 21.5,140.2 235.3,16.7 663.2,263.4 ",
     style: {
       fill: 'rgb(148, 242, 200)'
     }
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     points: "234.8,757.9 21.5,634.5 235.3,511 449.1,634.5 ",
     style: {
       fill: 'rgb(164, 117, 244)'
@@ -21633,31 +20827,31 @@ function FlareIcon() {
 }
 
 function IgnitionIcon() {
-  return /*#__PURE__*/React__default.createElement("svg", {
+  return React__default.createElement("svg", {
     id: "ignition",
     className: "w-8 h-8 -ml-1",
     viewBox: "0 0 500 500"
-  }, /*#__PURE__*/React__default.createElement("g", null, /*#__PURE__*/React__default.createElement("polygon", {
+  }, React__default.createElement("g", null, React__default.createElement("polygon", {
     style: {
       fill: 'transparent'
     },
     points: "466.5,375 466.5,125 250,0 33.5,125 33.5,375 250,500 \t"
-  }), /*#__PURE__*/React__default.createElement("g", null, /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("g", null, React__default.createElement("polygon", {
     style: {
       fill: '#ff4590'
     },
     points: "314.2,176 314.2,250 250,287 250,212.6 \t\t"
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     style: {
       fill: '#ffd000'
     },
     points: "185.9,398.1 185.9,324.1 250,287 249.9,360.9 \t\t"
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     style: {
       fill: '#de075d'
     },
     points: "250,139.1 250,287 185.9,250 185.8,101.9 \t\t"
-  }), /*#__PURE__*/React__default.createElement("polygon", {
+  }), React__default.createElement("polygon", {
     style: {
       fill: '#e0b800'
     },

--- a/src/components/context/ContextSections.tsx
+++ b/src/components/context/ContextSections.tsx
@@ -41,7 +41,7 @@ export default function ContextSections({ children }: Props) {
                     </ContextNav>
                 </div>
             </nav>
-            <div className="overflow-hidden grid grid-cols-1 gap-px shadow-lg flex-grow">{children}</div>
+            <div className="overflow-hidden grid grid-cols-1 gap-px bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 flex-grow">{children}</div>
         </>
     );
 }

--- a/src/components/debug/DebugTabs.tsx
+++ b/src/components/debug/DebugTabs.tsx
@@ -30,7 +30,7 @@ export default function DebugTabs({ children }: Props) {
     const Tab = tabs[currentTabIndex].component;
 
     return (
-        <div className="bg-gray-300/50 dark:bg-black/10 shadow-inner">
+        <div className="bg-gray-300/50 dark:bg-black/10 shadow-inner rounded-lg">
             <nav className="z-10 flex justify-center items-center">
                 <ul className="-my-5 flex justify-start items-center rounded-full shadow-lg bg-indigo-500 text-white space-x-px">
                     {tabs.map((tab, i) => (

--- a/src/components/errorCard/ErrorCard.tsx
+++ b/src/components/errorCard/ErrorCard.tsx
@@ -17,7 +17,7 @@ export default function ErrorCard() {
 
     return (
         <ErrorBoundary>
-            <section className="lg:flex items-stretch ~bg-white shadow-lg">
+            <section className="lg:flex items-stretch bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20">
                 <main id="exception" className="z-10 flex-grow min-w-0">
                     <div className="overflow-hidden">
                         <div className="px-6 sm:px-10 py-8 overflow-x-auto">

--- a/src/components/stackTrace/components/StackTrace.tsx
+++ b/src/components/stackTrace/components/StackTrace.tsx
@@ -52,7 +52,7 @@ export default function StackTrace({ openFrameIndex }: Props) {
     });
 
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-[33.33%,66.66%] lg:grid-rows-[57rem] items-stretch shadow-lg ~bg-white overflow-hidden">
+        <div className="grid grid-cols-1 lg:grid-cols-[33.33%,66.66%] lg:grid-rows-[57rem] items-stretch bg-white dark:shadow-none dark:bg-gray-800/50 dark:bg-gradient-to-bl from-gray-700/50 via-transparent dark:ring-1 dark:ring-inset dark:ring-white/5 rounded-lg shadow-2xl shadow-gray-500/20 overflow-hidden">
             <aside className="z-30 flex flex-col border-r ~border-gray-200">
                 <div className="max-h-[33vh] lg:max-h-[none] lg:absolute inset-0 flex flex-col overflow-hidden ~bg-white">
                     <header className="flex-none px-6 sm:px-10 h-16 flex items-center justify-start ~bg-white border-b ~border-gray-200">

--- a/src/components/ui/DefinitionList.tsx
+++ b/src/components/ui/DefinitionList.tsx
@@ -24,15 +24,17 @@ export default function DefinitionList({ children, className = '', ...props }: P
 
 DefinitionList.Row = DefinitionListRow;
 
+type Value = string | React.ReactNode | Array<any> | Object | boolean | number;
+
 type DefinitionListRowProps = {
-    value?: string | React.ReactNode | Array<any> | Object | boolean;
+    value?: Value;
     label?: string | React.ReactNode;
     className?: string;
     stacked?: boolean;
 };
 
 function DefinitionListRow({ value = '', label = '', className = '', stacked = false }: DefinitionListRowProps) {
-    let valueOutput: React.ReactNode = value;
+    let valueOutput = value;
     const [expandLabel, setExpandLabel] = useState(false);
 
     let timeout: NodeJS.Timeout;
@@ -52,7 +54,7 @@ function DefinitionListRow({ value = '', label = '', className = '', stacked = f
         valueOutput = (
             <span
                 className={`${
-                    value ? 'text-emerald-500 bg-emerald-500/5' : 'text-red-500 bg-red-500/5'
+                    value ? 'text-emerald-500 bg-emerald-500/5' : 'text-red-500 bg-red-800/5'
                 } text-sm px-3 py-2 inline-flex gap-2 items-center justify-center`}
             >
                 <FontAwesomeIcon
@@ -91,7 +93,7 @@ function DefinitionListRow({ value = '', label = '', className = '', stacked = f
             >
                 {label}
             </dt>
-            <dd className="flex-grow min-w-0">{valueOutput}</dd>
+            <dd className="flex-grow min-w-0">{valueOutput as React.ReactNode}</dd>
         </div>
     );
 }

--- a/src/components/ui/UnorderedList.tsx
+++ b/src/components/ui/UnorderedList.tsx
@@ -5,7 +5,7 @@ import { jsonStringify } from '../../util';
 type Props = {
     className?: string;
     style?: React.CSSProperties;
-    children?: React.ReactNode | Array<React.ReactNode>;
+    children?: React.ReactNode | React.ReactNodeArray;
 };
 
 export default function UnorderedList({ children, className = '', ...props }: Props) {
@@ -22,12 +22,14 @@ export default function UnorderedList({ children, className = '', ...props }: Pr
 
 UnorderedList.Item = UnorderedListItem;
 
+type Value = string | React.ReactNode | Array<any> | Object;
+
 type UnorderedListItemProps = {
-    value?: string | React.ReactNode | Array<any> | Object;
+    value?: Value;
 };
 
 function UnorderedListItem({ value = '' }: UnorderedListItemProps) {
-    let valueOutput: React.ReactNode = value;
+    let valueOutput = value;
 
     if (React.isValidElement(value)) {
         valueOutput = value;
@@ -37,5 +39,5 @@ function UnorderedListItem({ value = '' }: UnorderedListItemProps) {
         valueOutput = <CodeSnippet value={value} />;
     }
 
-    return <li>{valueOutput}</li>;
+    return <li>{valueOutput as React.ReactNode}</li>;
 }

--- a/types/components/context/Context.d.ts
+++ b/types/components/context/Context.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Context(): JSX.Element;

--- a/types/components/context/ContextList.d.ts
+++ b/types/components/context/ContextList.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     items: Record<string, string | object | boolean>;
 };

--- a/types/components/context/sections/Body.d.ts
+++ b/types/components/context/sections/Body.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Body(): JSX.Element | null;

--- a/types/components/context/sections/Cookies.d.ts
+++ b/types/components/context/sections/Cookies.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { CookiesContext } from '../../../types';
 declare type Props = {
     cookies: CookiesContext;

--- a/types/components/context/sections/Files.d.ts
+++ b/types/components/context/sections/Files.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Files(): JSX.Element | null;

--- a/types/components/context/sections/Git.d.ts
+++ b/types/components/context/sections/Git.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { GitContext } from '../../../types';
 declare type Props = {
     git: GitContext;

--- a/types/components/context/sections/Headers.d.ts
+++ b/types/components/context/sections/Headers.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { HeadersContext } from '../../../types';
 declare type Props = {
     headers: HeadersContext;

--- a/types/components/context/sections/LivewireComponent.d.ts
+++ b/types/components/context/sections/LivewireComponent.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function LivewireComponent(): JSX.Element | null;

--- a/types/components/context/sections/LivewireData.d.ts
+++ b/types/components/context/sections/LivewireData.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function LivewireData(): JSX.Element | null;

--- a/types/components/context/sections/LivewireUpdates.d.ts
+++ b/types/components/context/sections/LivewireUpdates.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function LivewireUpdates(): JSX.Element | null;

--- a/types/components/context/sections/QueryString.d.ts
+++ b/types/components/context/sections/QueryString.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { RequestDataContext } from '../../../types';
 declare type Props = {
     requestData: RequestDataContext;

--- a/types/components/context/sections/Request.d.ts
+++ b/types/components/context/sections/Request.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { HeadersContext, RequestContext, RequestDataContext } from '../../../types';
 declare type Props = {
     request: RequestContext;

--- a/types/components/context/sections/Routing.d.ts
+++ b/types/components/context/sections/Routing.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { RouteContext } from '../../../types';
 export default function Routing({ route }: {
     route: RouteContext;

--- a/types/components/context/sections/Session.d.ts
+++ b/types/components/context/sections/Session.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { SessionContext } from '../../../types';
 declare type Props = {
     session: SessionContext;

--- a/types/components/context/sections/User.d.ts
+++ b/types/components/context/sections/User.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { UserContext } from '../../../types';
 export default function User({ user }: {
     user: UserContext;

--- a/types/components/context/sections/Versions.d.ts
+++ b/types/components/context/sections/Versions.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { EnvContext } from '../../../types';
 export default function Versions({ env }: {
     env: EnvContext;

--- a/types/components/context/sections/View.d.ts
+++ b/types/components/context/sections/View.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function View(): JSX.Element | null;

--- a/types/components/debug/Debug.d.ts
+++ b/types/components/debug/Debug.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Debug(): JSX.Element;

--- a/types/components/debug/tabs/Dumps.d.ts
+++ b/types/components/debug/tabs/Dumps.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Dumps(): JSX.Element;

--- a/types/components/debug/tabs/Glows.d.ts
+++ b/types/components/debug/tabs/Glows.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Glows(): JSX.Element;

--- a/types/components/debug/tabs/Logs.d.ts
+++ b/types/components/debug/tabs/Logs.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Logs(): JSX.Element;

--- a/types/components/debug/tabs/Queries.d.ts
+++ b/types/components/debug/tabs/Queries.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Queries(): JSX.Element;

--- a/types/components/errorCard/ErrorCard.d.ts
+++ b/types/components/errorCard/ErrorCard.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function ErrorCard(): JSX.Element;

--- a/types/components/errorCard/ExceptionSelector.d.ts
+++ b/types/components/errorCard/ExceptionSelector.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function ExceptionSelector(): JSX.Element;

--- a/types/components/errorCard/Solution.d.ts
+++ b/types/components/errorCard/Solution.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { ErrorSolution } from '../../types';
 declare type Props = {
     solution: ErrorSolution;

--- a/types/components/errorCard/SolutionDescription.d.ts
+++ b/types/components/errorCard/SolutionDescription.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { ErrorSolution } from '../../types';
 declare type Props = {
     solution: ErrorSolution;

--- a/types/components/errorCard/SolutionRunner.d.ts
+++ b/types/components/errorCard/SolutionRunner.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { ErrorSolution } from '../../types';
 declare type Props = {
     solution: ErrorSolution;

--- a/types/components/errorCard/Solutions.d.ts
+++ b/types/components/errorCard/Solutions.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function Solutions(): JSX.Element;

--- a/types/components/stackTrace/components/FrameCodeSnippet.d.ts
+++ b/types/components/stackTrace/components/FrameCodeSnippet.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { ErrorFrame } from '../../../types';
 export declare type Row = Node[];
 declare type Node = {

--- a/types/components/stackTrace/components/FrameCodeSnippetLine.d.ts
+++ b/types/components/stackTrace/components/FrameCodeSnippetLine.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { ErrorFrame } from '../../../types';
 import { Row } from './FrameCodeSnippet';
 declare type Props = {

--- a/types/components/stackTrace/components/FrameGroup.d.ts
+++ b/types/components/stackTrace/components/FrameGroup.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 import { StackFrameGroupType } from '../../../types';
 declare type Props = {
     frameGroup: StackFrameGroupType;

--- a/types/components/stackTrace/components/StackTrace.d.ts
+++ b/types/components/stackTrace/components/StackTrace.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     openFrameIndex?: number;
 };

--- a/types/components/ui/CodeSnippet.d.ts
+++ b/types/components/ui/CodeSnippet.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     value: string;
     limitHeight?: boolean;

--- a/types/components/ui/CopyButton.d.ts
+++ b/types/components/ui/CopyButton.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     value: string;
     className?: string;

--- a/types/components/ui/DefinitionList.d.ts
+++ b/types/components/ui/DefinitionList.d.ts
@@ -9,8 +9,9 @@ declare namespace DefinitionList {
     var Row: typeof DefinitionListRow;
 }
 export default DefinitionList;
+declare type Value = string | React.ReactNode | Array<any> | Object | boolean | number;
 declare type DefinitionListRowProps = {
-    value?: string | React.ReactNode | Array<any> | Object | boolean;
+    value?: Value;
     label?: string | React.ReactNode;
     className?: string;
     stacked?: boolean;

--- a/types/components/ui/EditorLink.d.ts
+++ b/types/components/ui/EditorLink.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     path: string;
     lineNumber?: number;

--- a/types/components/ui/ErrorBoundaryCard.d.ts
+++ b/types/components/ui/ErrorBoundaryCard.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     githubLink: string;
 };

--- a/types/components/ui/ErrorBoundarySection.d.ts
+++ b/types/components/ui/ErrorBoundarySection.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     className?: string;
     githubLink: string;

--- a/types/components/ui/ExceptionMessage.d.ts
+++ b/types/components/ui/ExceptionMessage.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     message: string;
     className?: string;

--- a/types/components/ui/FormattedExceptionMessage.d.ts
+++ b/types/components/ui/FormattedExceptionMessage.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     message: string;
     exceptionClass: string;

--- a/types/components/ui/RelaxedFilePath.d.ts
+++ b/types/components/ui/RelaxedFilePath.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     path: string;
     lineNumber?: null | number;

--- a/types/components/ui/RelaxedFullyQualifiedClassName.d.ts
+++ b/types/components/ui/RelaxedFullyQualifiedClassName.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     path: string;
     lineNumber?: null | number;

--- a/types/components/ui/SfDump.d.ts
+++ b/types/components/ui/SfDump.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     value: string;
 };

--- a/types/components/ui/UnorderedList.d.ts
+++ b/types/components/ui/UnorderedList.d.ts
@@ -2,14 +2,15 @@ import React from 'react';
 declare type Props = {
     className?: string;
     style?: React.CSSProperties;
-    children?: React.ReactNode | Array<React.ReactNode>;
+    children?: React.ReactNode | React.ReactNodeArray;
 };
 declare function UnorderedList({ children, className, ...props }: Props): JSX.Element;
 declare namespace UnorderedList {
     var Item: typeof UnorderedListItem;
 }
 export default UnorderedList;
+declare type Value = string | React.ReactNode | Array<any> | Object;
 declare type UnorderedListItemProps = {
-    value?: string | React.ReactNode | Array<any> | Object;
+    value?: Value;
 };
 declare function UnorderedListItem({ value }: UnorderedListItemProps): JSX.Element;

--- a/types/components/ui/icons/FlareIcon.d.ts
+++ b/types/components/ui/icons/FlareIcon.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function FlareIcon(): JSX.Element;

--- a/types/components/ui/icons/IgnitionIcon.d.ts
+++ b/types/components/ui/icons/IgnitionIcon.d.ts
@@ -1,1 +1,2 @@
+/// <reference types="react" />
 export default function IgnitionIcon(): JSX.Element;

--- a/types/components/ui/icons/LivewireIcon.d.ts
+++ b/types/components/ui/icons/LivewireIcon.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="react" />
 declare type Props = {
     className?: string;
 };


### PR DESCRIPTION
Slightly tweaks some card UI's to better match Laravel's [new splash screen](https://twitter.com/taylorotwell/status/1623410252614967296). It's by no means a new design and additional UI components could still use some love (e.g. share & settings dropdowns).

In bullets:
- adds the dotted background
- rounds corners
- semi-transparent gradient bg + border in dark mode

In dark mode:
<img width="1752" alt="image" src="https://user-images.githubusercontent.com/6287961/221910328-f753ade2-655c-47e6-b912-df3365facee9.png">


In light mode:
<img width="1778" alt="image" src="https://user-images.githubusercontent.com/6287961/221909969-c193b0d5-1f60-4362-af0c-1ef9d78723ad.png">

Typescript be like:
![image](https://user-images.githubusercontent.com/6287961/221909205-870dfc1b-cf3b-4aac-9170-fd9cf35ce7ec.png)
