### PR TITLE
Fix collapse vendor frames on Windows

### DIFF
--- a/dist/index.modern.js
+++ b/dist/index.modern.js
@@ -202,7 +202,7 @@ function addFrameNumbers(frames) {
   }));
 }
 function getFrameType(frame) {
-  if (frame.relative_file.startsWith('vendor/')) {
+  if (frame.relative_file.startsWith('vendor/') || frame.relative_file.startsWith('vendor\\')) {
     return 'vendor';
   }
 
@@ -1379,7 +1379,7 @@ function stackReducer(state, action) {
 
     case 'COLLAPSE_ALL_VENDOR_FRAMES':
       {
-        const applicationFrameNumbers = addFrameNumbers(state.frames).filter(frame => !frame.relative_file.startsWith('vendor/') && frame.relative_file !== 'unknown').map(frame => frame.frame_number);
+        const applicationFrameNumbers = addFrameNumbers(state.frames).filter(frame => !frame.relative_file.startsWith('vendor/') && !frame.relative_file.startsWith('vendor\\') && frame.relative_file !== 'unknown').map(frame => frame.frame_number);
         const expanded = uniq_1([...applicationFrameNumbers]);
         return _extends$1({}, state, {
           expanded

--- a/src/components/stackTrace/helpers.ts
+++ b/src/components/stackTrace/helpers.ts
@@ -8,7 +8,7 @@ export function addFrameNumbers(frames: Array<ErrorFrame>): Array<ErrorFrame & {
 }
 
 export function getFrameType(frame: ErrorFrame): FrameType {
-    if (frame.relative_file.startsWith('vendor/')) {
+    if (frame.relative_file.startsWith('vendor/') || frame.relative_file.startsWith('vendor\\')) {
         return 'vendor';
     }
 

--- a/src/components/stackTrace/reducer.ts
+++ b/src/components/stackTrace/reducer.ts
@@ -18,7 +18,7 @@ export default function stackReducer(state: State, action: Action): State {
         }
         case 'COLLAPSE_ALL_VENDOR_FRAMES': {
             const applicationFrameNumbers = addFrameNumbers(state.frames)
-                .filter((frame) => !frame.relative_file.startsWith('vendor/') && frame.relative_file !== 'unknown')
+                .filter((frame) => !frame.relative_file.startsWith('vendor/') && !frame.relative_file.startsWith('vendor\\') && frame.relative_file !== 'unknown')
                 .map((frame) => frame.frame_number);
 
             const expanded = uniq([...applicationFrameNumbers]);


### PR DESCRIPTION
Hello,

This fixes the Collapse vendor frames button that doesn't work on Windows.
The bug is caused by different directory separator.
This PR adds test for Windows type directory separator.

Regards,
Karel