### PR TITLE
Add support for Editor urls that require opening in background

### DIFF
--- a/src/components/stackTrace/components/FrameCodeSnippetLine.tsx
+++ b/src/components/stackTrace/components/FrameCodeSnippetLine.tsx
@@ -21,7 +21,7 @@ export default function FrameCodeSnippetLine({
     frame,
     lineNumber
 }: Props) {
-    const editorUrl = useEditorUrl({ file: frame.file, lineNumber });
+    const editorUrlData = useEditorUrl({ file: frame.file, lineNumber });
 
     return (
         <span
@@ -30,9 +30,9 @@ export default function FrameCodeSnippetLine({
                 ${highlight ? ' ~bg-red-500/20' : ''}
             `}
         >
-            {editorUrl && (
+            {editorUrlData.url && (
                 <span className="z-30 opacity-0 group-hover:opacity-100 sticky left-10 w-0 h-full">
-                    <a href={editorUrl} className="-ml-3 block">
+                    <a href={editorUrlData.url} onClick={editorUrlData.onClick} className="-ml-3 block">
                         <RoundedButton>
                             <FontAwesomeIcon className="text-xs" icon={faPencilAlt} />
                         </RoundedButton>

--- a/src/components/ui/EditorLink.tsx
+++ b/src/components/ui/EditorLink.tsx
@@ -9,10 +9,10 @@ type Props = {
 };
 
 export default function EditorLink({ path, lineNumber, className }: Props) {
-    const editorUrl = useEditorUrl({ file: path, lineNumber });
+    const editorUrlData = useEditorUrl({ file: path, lineNumber });
 
     return (
-        <a href={editorUrl || '#'} className={`hover:underline ${className}`}>
+        <a href={editorUrlData.url || '#'} onClick={editorUrlData.onClick} className={`hover:underline ${className}`}>
             <RelaxedFilePath path={path} lineNumber={lineNumber} />
         </a>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type IgnitionConfig = {
     editor: string;
-    editorOptions: { [editor: string]: { label: string; url: string } };
+    editorOptions: { [editor: string]: { label: string; url: string, openInBackground: boolean } };
     remoteSitesPath: string;
     localSitesPath: string;
     theme: 'light' | 'dark' | 'auto';


### PR DESCRIPTION
Continuation of https://github.com/spatie/ignition/pull/262.

Some editors, like the newly added phpstorm-remote require its links to be opened in a background request. Otherwise the link opens a blank page.

This is a proposition to add a new optional boolean `openInBackground` to the `editor_options` config for Ignition:

https://github.com/spatie/ignition/blob/bde77df1dfb71b07a97f6f35c4bbf103e7a35b7d/src/Config/IgnitionConfig.php#L155

What `IgnitionConfig.php` would look like:
```php
          'editor_options' => [
                'sublime' => [
                    'label' => 'Sublime',
                    'url' => 'subl://open?url=file://%path&line=%line',
                ],
               //...
                'phpstorm-remote' => [
                    'openInBackground' => true,
                    'label' => 'PHPStorm Remote',
                    'url' => 'http://localhost:63342/api/file/%path:%line',
                ],
```

What do you think?